### PR TITLE
Use OPENSHIFT_ANSIBLE_IMAGE on ansible launch_gcp job

### DIFF
--- a/sjb/config/test_cases/test_pull_request_openshift_ansible_launch_gce.yml
+++ b/sjb/config/test_cases/test_pull_request_openshift_ansible_launch_gce.yml
@@ -10,6 +10,11 @@ overrides:
     - name: "image-registry"
     - name: "kubernetes-metrics-server"
 extensions:
+  parameters:
+    - name: "OPENSHIFT_ANSIBLE_IMAGE"
+      description: >
+        The image to install the cluster with. If not set, the job will not build this image.
+      default_value: openshift/origin-ansible:latest
   actions:
     - type: "script"
       title: "hold for user action"

--- a/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
+++ b/sjb/generated/test_pull_request_openshift_ansible_launch_gce.xml
@@ -39,12 +39,6 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>OPENSHIFT_ANSIBLE_IMAGE</name>
-          <description>The image to install the cluster with. If set, defaults to the value defined by the &lt;a href=&#39;https://github.com/openshift/release/blob/master/cluster/bin/local.sh&#39;&gt;&lt;code&gt;cluster/bin/local.sh&lt;/code&gt;&lt;/a&gt; script.
-</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
           <name>ADDITIONAL_SKIP</name>
           <description>Regular expression to filter additional tests from the conformance suite.
 See also:
@@ -59,6 +53,12 @@ See also:
 &lt;a style=&#34;display: block&#34; href=&#39;https://github.com/openshift/origin/issues/12072&#39;&gt;&lt;code&gt;origin&lt;/code&gt; issue 12072&lt;/a&gt;&lt;/br&gt;
 &lt;/div&gt;</description>
           <defaultValue>|should provide DNS for services|should support subPath|should work with TCP \(when fully idled\)|should test kubelet managed /etc/hosts file|\[networking\]\[router\]|\[Area:Networking\]\[Feature:Router\]|Downward API volume should update annotations on modification|should run a deployment to completion and then scale to zero|Basic StatefulSet functionality Scaling down before scale up is finished should wait until current pod will be running and ready before it will be removed|Probing container should \*not\* be restarted with a /healthz http liveness probe</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>OPENSHIFT_ANSIBLE_IMAGE</name>
+          <description>The image to install the cluster with. If not set, the job will not build this image.
+</description>
+          <defaultValue>openshift/origin-ansible:latest</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>OPENSHIFT_ANSIBLE_TARGET_BRANCH</name>


### PR DESCRIPTION
Was accidentally omitted, want to test it prior to roll out.