### PR TITLE
odo-sync busted: More bash settings, don't for loop

### DIFF
--- a/build-scripts/rcm-guest/publish-odo-binary.sh
+++ b/build-scripts/rcm-guest/publish-odo-binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux
+set -euxo pipefail
 
 SSH_OPTS="-l jenkins_aos_cd_bot -o StrictHostKeychecking=no use-mirror-upload.ops.rhcloud.com"
 
@@ -29,10 +29,7 @@ mkdir "${OUTDIR}"
 pushd ${OUTDIR}
 
 #download all release assests
-for item in ${DOWNLOADS};
-do
-    wget ${item}
-done
+echo $DOWNLOADS | xargs wget
 popd
 
 # create latest symlink


### PR DESCRIPTION
Trying to see if there's an error in here that we're missing. Right now the script just aborts as if there's nothing after the `Fetching ODO client ...` line.

```
+ echo 'Fetching ODO client v1.0.0-beta4'
+ rm -rf /tmp/odobinary.dBJFGqUxq8
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
$ ssh-agent -k
...
```