### PR TITLE
Failures could be null, replace with []

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -855,9 +855,9 @@ def get_distgit_notify( record_log ) {
     }
 
     source = record_log.get("source_alias", [])
-    commit = record_log["distgit_commit"]
-    def failure = record_log["distgit_commit_failure"]
-    notify = record_log["dockerfile_notify"]
+    commit = record_log.get("distgit_commit", [])
+    def failure = record_log.get("distgit_commit_failure", [])
+    notify = record_log.get("dockerfile_notify", [])
 
     int i = 0
     def source_alias = [:]


### PR DESCRIPTION
from https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/1405/console

```
java.lang.NullPointerException: Cannot invoke method size() on null object
	at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:91)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:48)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.NullCallSite.call(NullCallSite.java:35)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.kohsuke.groovy.sandbox.impl.Checker$1.call(Checker.java:160)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedCall(Checker.java:162)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.methodCall(SandboxInvoker.java:17)
	at Script2.get_distgit_notify(Script2.groovy:883)
	at Script2.notify_dockerfile_reconciliations(Script2.groovy:906)
	at Script1.stageUpdateDistgit(Script1.groovy:335)
	at WorkflowScript.run(WorkflowScript:114)
	at ___cps.transform___(Native Method)
	at com.cloudbees.groovy.cps.impl.ContinuationGroup.methodCall(ContinuationGroup.java:84)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.dispatchOrArg(FunctionCallBlock.java:113)
	at com.cloudbees.groovy.cps.impl.FunctionCallBlock$ContinuationImpl.fixName(FunctionCallBlock.java:78)
	at sun.reflect.GeneratedMethodAccessor86.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
....
```