### PR TITLE
Send more automated mailers to the automation list

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -90,7 +90,6 @@ node {
                         defaultValue: [
                             'aos-cicd@redhat.com',
                             'aos-qe@redhat.com',
-                            'aos-team-art@redhat.com',
                             'aos-art-automation+new-release@redhat.com',
                         ].join(',')
                     ],
@@ -237,7 +236,7 @@ node {
                     if (!params.DRY_RUN) {
                         commonlib.email(
                             to: "openshift-ccs@redhat.com",
-                            cc: "aos-team-art@redhat.com",
+                            cc: "aos-art-automation+image-list@redhat.com",
                             replyTo: "aos-team-art@redhat.com",
                             subject: "OCP ${release_name} (${arch}) Image List",
                             body: readFile(filename)
@@ -250,7 +249,7 @@ node {
             }
 
             buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
-            stage("mirror tools") { 
+            stage("mirror tools") {
               retry(3) {
                 release.stagePublishClient(quay_url, dest_release_tag, release_name, arch, CLIENT_TYPE)
               }

--- a/jobs/build/set_client_latest/Jenkinsfile
+++ b/jobs/build/set_client_latest/Jenkinsfile
@@ -47,7 +47,7 @@ node {
                         description: 'Failure Mailing List',
                         $class: 'hudson.model.StringParameterDefinition',
                         defaultValue: [
-                            'aos-team-art@redhat.com'
+                            'aos-art-automation+failed-setting-client-latest@redhat.com'
                         ].join(',')
                     ],
                     commonlib.mockParam(),


### PR DESCRIPTION
Spare the team discussion list from these automation mails.

* Error setting latest ocp client
* Success building release payload
* OCP 4.y.z ($ARCH) Image List