### PR TITLE
promote: Specify working target for clusterbot

### DIFF
--- a/jobs/build/release/Jenkinsfile
+++ b/jobs/build/release/Jenkinsfile
@@ -318,7 +318,7 @@ node {
                     return
                 }
                 try {  // don't let a slack outage break the job at this point
-                    def modeOptions = [ 'aws', 'gcp', 'azure,mirror' ]
+                    def modeOptions = [ 'aws', 'gcp', 'azure' ]
                     def testIndex = 0
                     def testLines = []
                     for ( String from_release : previousList) {
@@ -332,7 +332,7 @@ node {
                         return
                     }
                     slackChannel.say("Hi @release-artists . A new release is ready and needs some upgrade tests to be triggered. "
-                        + "Please open a chat with @cluster-bot and issue each of these lines individually. Note: mirror variant is broken for upgrade tests at this time, just use 'azure' instead.:\n${testLines.join('\n')}")
+                        + "Please open a chat with @cluster-bot and issue each of these lines individually:\n${testLines.join('\n')}")
                 } catch(ex) {
                     echo "slack notification failed: ${ex}"
                 }


### PR DESCRIPTION
Let's remove the warning to execute a `sed` on what needs to be done, and write what needs to be done directly.