### PR TITLE
jobs/build/promote/Jenkinsfile: don't include 'skip' in tests

### DIFF
--- a/jobs/build/promote/Jenkinsfile
+++ b/jobs/build/promote/Jenkinsfile
@@ -546,7 +546,7 @@ node {
                         acquire_failure = '****Doozer was not able to acquire data from Cincinnati. Inputs will need to be determined manually****. '
                         echo acquire_failure
                     }
-                    upgradeTestList = commonlib.parseList(calcUpgradeTestOut) + in_flight_prev
+                    upgradeTestList = commonlib.parseList(calcUpgradeTestOut) + (in_flight_prev_required ? in_flight_prev : [])
 
                     for ( String from_release : upgradeTestList) {
                         mode = modeOptions[testIndex % modeOptions.size()]


### PR DESCRIPTION
4.7 tests included "skip" among the upgrade tests, because the list of previous is re-evaluated at that point and `in_flight_prev` added unconditionally. this hopefully makes it conditional... but hard to test w/o running a release, so other eyes appreciated.