### PR TITLE
move slack notification from Jenkins file to python

### DIFF
--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -92,13 +92,6 @@ node {
                 currentBuild.displayName += " - $params.VERSION - $params.ASSEMBLY"
             }
         }
-        stage ("Notify release channel") {
-            if (params.DRY_RUN) {
-                return
-            }
-            slackChannel = slacklib.to(params.NAME?: params.VERSION)
-            slackChannel.say(":construction: prepare-release for ${params.NAME?: params.ASSEMBLY} :construction:")
-        }
         try {
             stage("prepare release") {
                 sh "mkdir -p ./artcd_working"
@@ -134,7 +127,7 @@ node {
                     }
                 }
                 sshagent(["openshift-bot"]) {
-                    withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                    withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
                         echo "Will run ${cmd}"
                         commonlib.shell(script: cmd.join(' '))
                     }
@@ -151,15 +144,6 @@ node {
                 "artcd_working/**/*.yaml",
                 "artcd_working/**/*.yml",
             ])
-            if (!params.DRY_RUN) {
-                slackChannel = slacklib.to(params.NAME?: params.VERSION)
-                if (currentBuild.currentResult == "SUCCESS") {
-                    slackChannel.say(":white_check_mark: prepare-release for ${params.NAME?: params.ASSEMBLY} completes.")
-                } else {
-                    slackChannel.say(":warning: prepare-release for ${params.NAME?: params.ASSEMBLY} has result ${currentBuild.currentResult}.")
-                }
-
-            }
             buildlib.cleanWorkspace()
         }
     }

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -85,7 +85,6 @@ class PrepareReleasePipeline:
                 raise ValueError("default_advisories cannot be set for a non-stream assembly.")
 
         self.release_date = date
-        self._slack_client = self.runtime.new_slack_client()
         self.package_owner = package_owner or self.runtime.config["advisory"]["package_owner"]
         self._slack_client = slack_client
         self.working_dir = self.runtime.working_dir.absolute()
@@ -763,7 +762,7 @@ update JIRA accordingly, then notify QE and multi-arch QE for testing.""")
 async def prepare_release(runtime: Runtime, group: str, assembly: str, name: Optional[str], date: str,
                           package_owner: Optional[str], nightlies: Tuple[str, ...], default_advisories: bool, include_shipped: bool):
     slack_client = runtime.new_slack_client()
-    slack_client.bind_channel(assembly)
+    slack_client.bind_channel(group)
     await slack_client.say(f":construction: prepare-release for {name if name else assembly} :construction:")
     try:
         # parse environment variables for credentials


### PR DESCRIPTION
test job:https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ximhan/job/build%252Fprepare-release/4/consoleFull
in this test job, all slack messages was triggered from the python script, like https://redhat-internal.slack.com/archives/C02CJ4FNYSV/p1678258108178919 and https://redhat-internal.slack.com/archives/C02CJ4FNYSV/p1678259017632839