### PR TITLE
[ART-5148] Add `oc-mirror.tar.gz` checksum to sha256sum.txt

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -510,6 +510,7 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
                 MOBY_DISABLE_PIGZ=true GOTRACEBACK=all oc image extract `oc adm release info ${quay_url}:${from_release_tag} --image-for=oc-mirror` --path /usr/bin/oc-mirror:${CLIENT_MIRROR_DIR}
                 pushd ${CLIENT_MIRROR_DIR}
                 tar zcvf oc-mirror.tar.gz oc-mirror
+                sha256sum oc-mirror.tar.gz >> sha256sum.txt
                 rm oc-mirror
                 popd
             fi


### PR DESCRIPTION
`oc-mirror.tar.gz` checksum is not being recorded in `sha256sum.txt`, and we got a request to include it. ([ART-5148](https://issues.redhat.com/browse/ART-5148))