### PR TITLE
Trigger build-microshift earlier

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -161,6 +161,9 @@ node {
         if (params.SKIP_ATTACH_CVE_FLAWS) {
             cmd << "--skip-attach-cve-flaws"
         }
+        if (params.SKIP_BUILD_MICROSHIFT) {
+            cmd << "--skip-build-microshift"
+        }
         if (params.PERMIT_PAYLOAD_OVERWRITE) {
             cmd << "--permit-overwrite"
         }
@@ -379,28 +382,10 @@ node {
     }
 
     stage("trigger build-microshift") {
-        if (params.SKIP_BUILD_MICROSHIFT) {
-            echo "Don't trigger build-microshift because SKIP_BUILD_MICROSHIFT is set"
-            return
-        }
         if (major == 4 && minor < 12) {
             echo "Skip microshift build for version < 4.12"
             return
         }
-        def mirror_path = "/pockets/microshift/${params.VERSION}-el8/${params.ASSEMBLY}"
-        if (commonlib.listS3Mirror(mirror_path + "/plashet.yml")) {
-            echo "Microshift for this assembly has been published to the pocket. If a rebuild is required, please manually run build-microshift job."
-            return
-        }
-        build(
-            job: "build%2Fbuild-microshift",
-            propagate: true,
-            parameters: [
-                string(name: 'BUILD_VERSION', value: params.VERSION),
-                string(name: 'ASSEMBLY', value: params.ASSEMBLY),
-                booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
-            ]
-        )
     }
 
     stage("clean and mail") {

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -381,13 +381,6 @@ node {
         }
     }
 
-    stage("trigger build-microshift") {
-        if (major == 4 && minor < 12) {
-            echo "Skip microshift build for version < 4.12"
-            return
-        }
-    }
-
     stage("clean and mail") {
         dry_subject = ""
         if (params.DRY_RUN) { dry_subject = "[DRY RUN] "}

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -62,7 +62,7 @@ async def trigger_build_sync(build_version: str):
 
 async def trigger_build_microshift(build_version: str, assembly: str, dry_run: bool):
     await trigger_jenkins_job(
-        job_path='job/triggered-builds/job/microshift',
+        job_path='job/triggered-builds/job/build-microshift',
         params={
             'BUILD_VERSION': build_version,
             'ASSEMBLY': assembly,

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -58,3 +58,14 @@ async def trigger_build_sync(build_version: str):
         job_path='job/triggered-builds/job/build-sync',
         params={'BUILD_VERSION': build_version}
     )
+
+
+async def trigger_build_microshift(build_version: str, assembly: str, dry_run: bool):
+    await trigger_jenkins_job(
+        job_path='job/triggered-builds/job/microshift',
+        params={
+            'BUILD_VERSION': build_version,
+            'ASSEMBLY': assembly,
+            'DRY_RUN': dry_run
+        }
+    )

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -436,7 +436,7 @@ class PromotePipeline:
 
     async def _build_microshift(self, releases_config):
         if self.skip_build_microshift:
-            self._logger.info("Skipping build-microshift because SKIP_BUILD_MICROSHIFT is set.")
+            self._logger.info("Skipping microshift build because SKIP_BUILD_MICROSHIFT is set.")
             return
 
         major, minor = util.isolate_major_minor_in_group(self.group)
@@ -444,11 +444,11 @@ class PromotePipeline:
             self._logger.info("Skip microshift build for version < 4.12")
             return
 
-        if not util.is_microshift_pinned(releases_config, self.assembly):
-            self._logger.info("Microshift is not pinned. Starting build...")
+        if not util.is_rpm_pinned(releases_config, self.assembly, 'microshift'):
+            self._logger.info("Microshift is not pinned in the assembly config. Starting build...")
             await trigger_build_microshift(self.group, self.assembly, self.runtime.dry_run)
         else:
-            self._logger.info("Microshift is pinned. Skipping build. If a rebuild is required, please manually run build-microshift job.")
+            self._logger.info("Microshift is pinned in the assembly config. Skipping build. If a rebuild is required, please manually run build-microshift job.")
 
     @staticmethod
     def get_live_id(advisory_info: Dict):

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -21,6 +21,7 @@ from pyartcd.cli import cli, click_coroutine, pass_runtime
 from pyartcd.exceptions import VerificationError
 from pyartcd.jira import JIRAClient
 from pyartcd.oc import get_release_image_info
+from pyartcd.jenkins import trigger_build_microshift
 from pyartcd.runtime import Runtime
 from ruamel.yaml import YAML
 from semver import VersionInfo
@@ -38,7 +39,9 @@ class PromotePipeline:
     def __init__(self, runtime: Runtime, group: str, assembly: str,
                  skip_blocker_bug_check: bool = False,
                  skip_attached_bug_check: bool = False, skip_attach_cve_flaws: bool = False,
-                 skip_image_list: bool = False, permit_overwrite: bool = False,
+                 skip_image_list: bool = False,
+                 skip_build_microshift: bool = False,
+                 permit_overwrite: bool = False,
                  no_multi: bool = False, multi_only: bool = False, use_multi_hack: bool = False) -> None:
         self.runtime = runtime
         self.group = group
@@ -47,6 +50,7 @@ class PromotePipeline:
         self.skip_attached_bug_check = skip_attached_bug_check
         self.skip_attach_cve_flaws = skip_attach_cve_flaws
         self.skip_image_list = skip_image_list
+        self.skip_build_microshift = skip_build_microshift
         self.permit_overwrite = permit_overwrite
 
         if multi_only and no_multi:
@@ -230,6 +234,10 @@ class PromotePipeline:
             tag_stable = assembly_type in [assembly.AssemblyTypes.STANDARD, assembly.AssemblyTypes.CANDIDATE, assembly.AssemblyTypes.PREVIEW]
             release_infos = await self.promote(assembly_type, release_name, arches, previous_list, metadata, reference_releases, tag_stable)
             self._logger.info("All release images for %s have been promoted.", release_name)
+
+            # Before waiting for release images to be accepted by release controllers,
+            # we can start microshift build
+            await self._build_microshift(releases_config)
 
             # Wait for payloads to be accepted by release controllers
             pullspecs = {arch: release_info["image"] for arch, release_info in release_infos.items()}
@@ -425,6 +433,22 @@ class PromotePipeline:
         if not isinstance(advisory_info, dict):
             raise ValueError(f"Got invalid advisory info for advisory {advisory}: {advisory_info}.")
         return advisory_info
+
+    async def _build_microshift(self, releases_config):
+        if self.skip_build_microshift:
+            self._logger.info("Skipping build-microshift because SKIP_BUILD_MICROSHIFT is set.")
+            return
+
+        major, minor = util.isolate_major_minor_in_group(self.group)
+        if major == 4 and minor < 12:
+            self._logger.info("Skip microshift build for version < 4.12")
+            return
+
+        if not util.is_microshift_pinned(releases_config, self.assembly):
+            self._logger.info("Microshift is not pinned. Starting build...")
+            await trigger_build_microshift(self.group, self.assembly, self.runtime.dry_run)
+        else:
+            self._logger.info("Microshift is pinned. Skipping build. If a rebuild is required, please manually run build-microshift job.")
 
     @staticmethod
     def get_live_id(advisory_info: Dict):
@@ -1000,6 +1024,8 @@ class PromotePipeline:
               help="Skip attaching CVE flaws.")
 @click.option("--skip-image-list", is_flag=True,
               help="Do not gather an advisory image list for docs.")
+@click.option("--skip-build-microshift", is_flag=True,
+              help="Do not build microshift rpm")
 @click.option("--permit-overwrite", is_flag=True,
               help="DANGER! Allows the pipeline to overwrite an existing payload.")
 @click.option("--no-multi", is_flag=True, help="Do not promote a multi-arch/heterogeneous payload.")
@@ -1010,8 +1036,11 @@ class PromotePipeline:
 async def promote(runtime: Runtime, group: str, assembly: str,
                   skip_blocker_bug_check: bool, skip_attached_bug_check: bool,
                   skip_attach_cve_flaws: bool, skip_image_list: bool,
+                  skip_build_microshift: bool,
                   permit_overwrite: bool, no_multi: bool, multi_only: bool, use_multi_hack: bool):
     pipeline = PromotePipeline(runtime, group, assembly,
                                skip_blocker_bug_check, skip_attached_bug_check, skip_attach_cve_flaws,
-                               skip_image_list, permit_overwrite, no_multi, multi_only, use_multi_hack)
+                               skip_image_list,
+                               skip_build_microshift,
+                               permit_overwrite, no_multi, multi_only, use_multi_hack)
     await pipeline.run()

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -110,6 +110,11 @@ def get_release_name_for_assembly(group_name: str, releases_config: Dict, assemb
     return doozerutil.get_release_name_for_assembly(group_name, model.Model(releases_config), assembly_name)
 
 
+def is_microshift_pinned(releases_config: Dict, assembly_name: str):
+    pinned_rpms = assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'members', {'rpms': []})['rpms']
+    return any(rpm['distgit_key'] == 'microshift' for rpm in pinned_rpms)
+
+
 async def kinit():
     logger.info('Initializing ocp-build kerberos credentials')
 

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -110,9 +110,9 @@ def get_release_name_for_assembly(group_name: str, releases_config: Dict, assemb
     return doozerutil.get_release_name_for_assembly(group_name, model.Model(releases_config), assembly_name)
 
 
-def is_microshift_pinned(releases_config: Dict, assembly_name: str):
+def is_rpm_pinned(releases_config: Dict, assembly_name: str, rpm_name: str):
     pinned_rpms = assembly._assembly_config_struct(model.Model(releases_config), assembly_name, 'members', {'rpms': []})['rpms']
-    return any(rpm['distgit_key'] == 'microshift' for rpm in pinned_rpms)
+    return any(rpm['distgit_key'] == rpm_name for rpm in pinned_rpms)
 
 
 async def kinit():

--- a/triggered-jobs/build-microshift/Jenkinsfile
+++ b/triggered-jobs/build-microshift/Jenkinsfile
@@ -1,0 +1,43 @@
+#!/usr/bin/env groovy
+
+node() {
+    checkout scm
+    commonlib = load("pipeline-scripts/commonlib.groovy")
+
+    commonlib.describeJob("build-microshift", """
+This job is meant to be triggered by remote API calls.
+It will forward the call to build/build-microshift,
+that being part of a multibranch pipeline could not be configured to receive remote triggers directly.<br>
+    """)
+
+    // Expose properties for a parameterized build
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '365',
+                    daysToKeepStr: '365')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}"
+
+    build(
+        job: '../aos-cd-builds/build%2Fbuild-microshift/',
+        propagate: false,
+        parameters: [
+            string(name: 'BUILD_VERSION', value: params.BUILD_VERSION),
+            string(name: 'ASSEMBLY', value: params.ASSEMBLY),
+            booleanParam(name: 'DRY_RUN', value: params.DRY_RUN),
+        ]
+    )
+}

--- a/triggered-jobs/build-microshift/Jenkinsfile
+++ b/triggered-jobs/build-microshift/Jenkinsfile
@@ -23,6 +23,17 @@ that being part of a multibranch pipeline could not be configured to receive rem
                 parameterDefinitions: [
                     commonlib.mockParam(),
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                    string(
+                        name: "ASSEMBLY",
+                        description: "The name of an assembly to rebase & build for. e.g. 4.9.1",
+                        defaultValue: "test",
+                        trim: true
+                    ),
+                    booleanParam(
+                        name: "DRY_RUN",
+                        description: "Take no action, just echo what the job would have done.",
+                        defaultValue: false
+                    ),
                 ]
             ],
         ]

--- a/triggered-jobs/build-microshift/Jenkinsfile
+++ b/triggered-jobs/build-microshift/Jenkinsfile
@@ -23,24 +23,15 @@ that being part of a multibranch pipeline could not be configured to receive rem
                 parameterDefinitions: [
                     commonlib.mockParam(),
                     commonlib.ocpVersionParam('BUILD_VERSION', '4'),
-                    string(
-                        name: "ASSEMBLY",
-                        description: "The name of an assembly to rebase & build for. e.g. 4.9.1",
-                        defaultValue: "test",
-                        trim: true
-                    ),
-                    booleanParam(
-                        name: "DRY_RUN",
-                        description: "Take no action, just echo what the job would have done.",
-                        defaultValue: false
-                    ),
+                    string(name: "ASSEMBLY", trim: true),
+                    booleanParam(name: "DRY_RUN", defaultValue: false),
                 ]
             ],
         ]
     )
 
     commonlib.checkMock()
-    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION}"
+    currentBuild.displayName = "#${currentBuild.number} - ${params.BUILD_VERSION} - ${params.ASSEMBLY}"
 
     build(
         job: '../aos-cd-builds/build%2Fbuild-microshift/',


### PR DESCRIPTION
Right now we trigger build-microshift as the last step in the promote job,
after a release is accepted.
The problem with that is 
- QEs need microshift advisory prepared with build and on_qa asap
- Release getting to accepted takes a long time (~6-8 hrs)
- We need to perform manual steps to prepare microshift adv right now

So we want to start the build as soon as we have promoted payloads.
I've used the same paradigm that @locriandev introduced w. ocp4_scan
of a triggered-builds job, so we can trigger from inside promote.py