### PR TITLE
[ART-6052] migrate promote job steps to python

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -114,6 +114,11 @@ node {
                         lock("build-microshift-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
                     }
                 }
+                def build_nvr = sh (
+                        script: "grep -oP '(?<=nvrs=)[^|]+' artcd_working/doozer-working/record.log",
+                        returnStdout: true
+                    ).trim()
+                currentBuild.description = build_nvr
             }
         } finally {
             stage("save artifacts") {

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -143,6 +143,7 @@ node {
             "-v",
             "--working-dir=./artcd_working",
             "--config=./config/artcd.toml",
+            "--mail-list-success=${params.MAIL_LIST_SUCCESS}",
         ]
         if (params.DRY_RUN) {
             cmd << "--dry-run"
@@ -167,6 +168,18 @@ node {
         if (params.PERMIT_PAYLOAD_OVERWRITE) {
             cmd << "--permit-overwrite"
         }
+        if (params.SKIP_MIRROR_BINARIES) {
+            cmd << "--skip-mirror-binaries"
+        }
+        if (params.SKIP_SIGNING) {
+            cmd << "--skip-signing"
+        }
+        if (params.SKIP_CINCINNATI_PR_CREATION) {
+            cmd << "--skip-cincinnati-pr-creation"
+        }
+        if (params.SKIP_OTA_SLACK_NOTIFICATION) {
+            cmd << "--skip-ota-slack-notification"
+        }
         if (params.NO_MULTI) {
             cmd << "--no-multi"
         }
@@ -181,14 +194,19 @@ node {
         }
         echo "Will run ${cmd}"
         buildlib.withAppCiAsArtPublish() {
-            withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'), string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'), string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')]) {
+            withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'creds_dev_registry.quay.io', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD'],
+                            aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                            string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')]) {
                 def out = sh(script: cmd.join(' '), returnStdout: true).trim()
                 echo "artcd returns:\n$out"
                 release_info = readJSON(text: out)
             }
         }
     }
-
+    /*
     buildlib.registry_quay_dev_login()  // chances are, earlier auth has expired
 
     def justifications =release_info.justifications ?: []
@@ -220,7 +238,8 @@ node {
             }
         }
     }
-
+    */
+    
     stage("sync RHCOS") {
         /*
          * This has inappropriate logic, disabling it for now.
@@ -265,7 +284,7 @@ node {
         }
         */
     }
-
+    /*
     stage("sign artifacts") {
         if (params.SKIP_SIGNING) {
             echo "Signing artifacts is skipped."
@@ -290,7 +309,7 @@ node {
             )
         }
     }
-
+    */
     stage("send release message") {
         if (release_info.type == "custom") {
             echo "Don't send release messages for a custom release."
@@ -312,7 +331,7 @@ node {
             release.sendReleaseCompleteMessage(["name": release_name], release_info.advisory ?: 0, release_info.live_url, arch)
         }
     }
-
+    /*
     stage("channel prs") {
         if (release_info.type == "custom") {
             echo "Skipping PR creation for custom (hotfix) release."
@@ -396,5 +415,6 @@ PullSpecs: ${pullspecs.join(",")}
         """);
         buildlib.cleanWorkspace()
     }
-
+    */
+    buildlib.cleanWorkspace()
 }

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -198,8 +198,12 @@ node {
                             aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            file(credentialsId: "0xffe0b38-openshift-art-bot.crt", variable: 'busCertificate'),
+                            file(credentialsId: "0xffe0b38-openshift-art-bot.key", variable: 'busKey'),
                             string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                             string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')]) {
+                cmd << "--ssl-cert" << "${busCertificate}"
+                cmd << "--ssl-key" << "${busKey}"
                 def out = sh(script: cmd.join(' '), returnStdout: true).trim()
                 echo "artcd returns:\n$out"
                 release_info = readJSON(text: out)
@@ -309,7 +313,6 @@ node {
             )
         }
     }
-    */
     stage("send release message") {
         if (release_info.type == "custom") {
             echo "Don't send release messages for a custom release."
@@ -331,7 +334,6 @@ node {
             release.sendReleaseCompleteMessage(["name": release_name], release_info.advisory ?: 0, release_info.live_url, arch)
         }
     }
-    /*
     stage("channel prs") {
         if (release_info.type == "custom") {
             echo "Skipping PR creation for custom (hotfix) release."

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -20,3 +20,4 @@ NIGHTLY_PAYLOAD_REPOS = {
 }
 
 OCP_BUILD_DATA_URL = 'https://github.com/openshift-eng/ocp-build-data'
+QUAY_URL = "quay.io/openshift-release-dev/ocp-release"

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -21,3 +21,5 @@ NIGHTLY_PAYLOAD_REPOS = {
 
 OCP_BUILD_DATA_URL = 'https://github.com/openshift-eng/ocp-build-data'
 QUAY_URL = "quay.io/openshift-release-dev/ocp-release"
+UMB_CI_Broker = [['umb-broker03.api.redhat.com', 61616], ['umb-broker04.api.redhat.com', 61616]]
+PROMOTE_TOPIC = "/topic/VirtualTopic.eng.ci.art.ocp-release.complete"

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import os
 import aiohttp
+from jenkinsapi.jenkins import Jenkins
 
 logger = logging.getLogger(__name__)
 
@@ -68,3 +69,12 @@ async def trigger_build_microshift(build_version: str, assembly: str, dry_run: b
             'DRY_RUN': dry_run
         }
     )
+
+
+def new_jenkins_client():
+    jenkins_server = "https://buildvm.hosts.prod.psi.bos.redhat.com:8443/"
+    try:
+        client = Jenkins(jenkins_server, username=os.environ['JENKINS_SERVICE_ACCOUNT'], password=os.environ['JENKINS_SERVICE_ACCOUNT_TOKEN'])
+    except Exception as e:
+        raise e
+    return client

--- a/pyartcd/pyartcd/oc.py
+++ b/pyartcd/pyartcd/oc.py
@@ -1,8 +1,12 @@
 import json
 import os
-
+import logging
 from pyartcd import exectools
 from pyartcd.runtime import Runtime
+import openshift as oc
+from openshift import Result
+
+logger = logging.getLogger(__name__)
 
 
 async def get_release_image_info(pullspec: str, raise_if_not_found: bool = False):
@@ -35,3 +39,47 @@ async def registry_login(runtime: Runtime):
     except ChildProcessError:
         runtime.logger.error('Failed to login into OC registry')
         raise
+
+
+def get_release_image_pullspec(release_pullspec: str, image: str):
+    # oc adm release info --image-for=<image> <pullspec>
+    with oc.tracking() as tracker:
+        try:
+            r = Result("adm")
+            r.add_action(oc.oc_action(oc.cur_context(), 'adm', cmd_args=['release', 'info', f'--image-for={image}', release_pullspec]))
+            if r.status() == 0:
+                logger.info(f"Output: {r.out().strip()}")
+            else:
+                logger.warn(r.err())
+        except Exception as e:
+            logger.error(tracker.get_result())
+            raise e
+    return r.status(), r.out().strip()
+
+
+def extract_release_binary(image_pullspec: str, path_args: list[str]):
+    # oc image extract --confirm --only-files --path=/usr/bin/..:<workdir> <pullspec>
+    with oc.tracking() as tracker:
+        try:
+            r = Result("image")
+            r.add_action(oc.oc_action(oc.cur_context(), 'image', cmd_args=['extract', '--confirm', '--only-files'] + path_args + [image_pullspec]))
+            r.fail_if("extract release binary failed")
+        except Exception as e:
+            logger.error(tracker.get_result())
+            raise e
+
+
+def extract_release_client_tools(release_pullspec: str, path_arg: str, arch: str):
+    # oc adm release extract --tools --command-os='*' -n ocp --to=<workdir> --filter-by-os=<arch> --from <pullspec>
+    with oc.tracking() as tracker:
+        try:
+            r = Result("tools")
+            if arch:
+                cmd_args = ["release", "extract", "--tools", "--command-os='*'", "-n=ocp", f"--filter-by-os={arch}", path_arg, release_pullspec]
+            else:
+                cmd_args = ["release", "extract", "--tools", "--command-os='*'", "-n=ocp", path_arg, release_pullspec]
+            r.add_action(oc.oc_action(oc.cur_context(), 'adm', cmd_args))
+            r.fail_if("extract release binary failed")
+        except Exception as e:
+            logger.error(tracker.get_result())
+            raise e

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -14,6 +14,8 @@ import io
 
 import aiohttp
 import click
+import datetime
+import stomp
 # from pyartcd.cincinnati import CincinnatiAPI
 from doozerlib import assembly
 from doozerlib.util import (brew_arch_for_go_arch, brew_suffix_for_arch,
@@ -38,7 +40,8 @@ yaml.default_flow_style = False
 class PromotePipeline:
     DEST_RELEASE_IMAGE_REPO = constants.RELEASE_IMAGE_REPO
 
-    def __init__(self, runtime: Runtime, group: str, assembly: str, mail_list_success: str,
+    def __init__(self, runtime: Runtime, group: str, ssl_cert: Optional[str], ssl_key: Optional[str],
+                 assembly: str, mail_list_success: str,
                  skip_blocker_bug_check: bool = False,
                  skip_attached_bug_check: bool = False, skip_attach_cve_flaws: bool = False,
                  skip_image_list: bool = False,
@@ -49,6 +52,8 @@ class PromotePipeline:
                  skip_ota_slack_notification: bool = False, use_multi_hack: bool = False) -> None:
         self.runtime = runtime
         self.group = group
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
         self.assembly = assembly
         self.mail_list_success = mail_list_success
         self.skip_blocker_bug_check = skip_blocker_bug_check
@@ -427,6 +432,11 @@ class PromotePipeline:
             for b in builds:
                 b.block_until_complete() if b.is_running() else None
 
+        # send release CI message
+        if not self.skip_signing and assembly_type.value != "custom" and not self.runtime.dry_run:
+            for arch in data["content"]:
+                self.runtime.send_ci_messages(arch, release_name, image_advisory, errata_url)
+
         # create cincinnati prs
         if assembly_type.value != "custom" and not self.skip_cincinnati_pr_creation and not self.runtime.dry_run:
             logger.info("Create cincinnati prs")
@@ -499,6 +509,51 @@ class PromotePipeline:
         self._logger.info("Insert microshift nvr into releases.yaml complete")
         return pr.html_url
 
+    def send_ci_messages(self, arch, releaseName, advisoryNumber, advisoryLiveUrl):
+        msg = {
+            "contact": {
+                "url": "https://mojo.redhat.com/docs/DOC-1178565",
+                "team": "OpenShift Automatic Release Team (ART)",
+                "email": "aos-team-art@redhat.com",
+                "name": "ART Jobs",
+                "slack": "#aos-art",
+            },
+            "run": {
+                "url": self.runtime.get_job_run_url(),
+                "log": f"{self.runtime.get_job_run_url()}/console",
+            },
+            "artifact": {
+                "type": "ocp-release",
+                "name": "ocp-release",
+                "version": releaseName,
+                "nvr": f"ocp-release-{releaseName}",
+                "architecture": arch,
+                "release_stream": "4-stable",
+                "release": {"name": releaseName},
+                "advisory": {
+                    "number": advisoryNumber,
+                    "live_url": advisoryLiveUrl,
+                },
+            },
+            "generated_at": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "version": "0.2.3",
+        }
+        headers = {
+            "messageType": "Custom",
+            "release": releaseName,
+            "release_stream": "4-stable",
+            "product": "OpenShift Container Platform",
+            "providerName": "Red Hat UMB",
+        }
+        conn = stomp.Connection11(host_and_ports=constants.UMB_CI_Broker)
+        conn.set_ssl(
+            for_hosts=constants.UMB_CI_Broker,
+            cert_file=self.ssl_cert,
+            key_file=self.ssl_key,
+        )
+        conn.connect()
+        conn.send(body=msg, headers=headers, destination=constants.PROMOTE_TOPIC)
+        conn.disconnect()
 
     def _pin_nvrs(self, nvrs: List[str], releases_config) -> Dict:
         """ Update releases.yml to pin the specified NVRs.
@@ -1205,6 +1260,8 @@ class PromotePipeline:
 @cli.command("promote")
 @click.option("-g", "--group", metavar='NAME', required=True,
               help="The group of components on which to operate. e.g. openshift-4.9")
+@click.option("--ssl-cert", help="prod umb certificate for message broker connection")
+@click.option("--ssl-key", help="prod umb key for message broker connection")
 @click.option("--assembly", metavar="ASSEMBLY_NAME", required=True,
               help="The name of an assembly. e.g. 4.9.1")
 @click.option("--mail-list-success", metavar="MAIL_LIST_SUCCESS", required=False,
@@ -1230,7 +1287,8 @@ class PromotePipeline:
 @click.option("--use-multi-hack", is_flag=True, help="Add '-multi' to heterogeneous payload name to workaround a Cincinnati issue")
 @pass_runtime
 @click_coroutine
-async def promote(runtime: Runtime, group: str, assembly: str, mail_list_success: str,
+async def promote(runtime: Runtime, group: str, ssl_cert: Optional[str], ssl_key: Optional[str],
+                  assembly: str, mail_list_success: str,
                   skip_blocker_bug_check: bool, skip_attached_bug_check: bool,
                   skip_attach_cve_flaws: bool, skip_image_list: bool,
                   skip_build_microshift: bool,
@@ -1238,7 +1296,7 @@ async def promote(runtime: Runtime, group: str, assembly: str, mail_list_success
                   skip_mirror_binaries: bool, skip_signing: bool,
                   skip_cincinnati_pr_creation: bool, skip_ota_slack_notification: bool,
                   use_multi_hack: bool):
-    pipeline = PromotePipeline(runtime, group, assembly, mail_list_success,
+    pipeline = PromotePipeline(runtime, group, ssl_cert, ssl_key, assembly, mail_list_success,
                                skip_blocker_bug_check, skip_attached_bug_check, skip_attach_cve_flaws,
                                skip_image_list, skip_build_microshift, permit_overwrite, no_multi,
                                multi_only, skip_mirror_binaries, skip_signing, skip_cincinnati_pr_creation,

--- a/pyartcd/pyartcd/runtime.py
+++ b/pyartcd/pyartcd/runtime.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import toml
-
+from github import Github
 from pyartcd.jira import JIRAClient
 from pyartcd.mail import MailService
 from pyartcd.slack import SlackClient
@@ -56,6 +56,12 @@ class Runtime:
 
     def new_mail_client(self):
         return MailService.from_config(self.config)
+
+    def new_github_client(self, github_token: Optional[str] = None):
+        token = github_token if github_token else os.environ.get("GITHUB_TOKEN")
+        if not token:
+            raise ValueError("GITHUB_TOKEN environment variable is not set")
+        return Github(token)
 
     def get_job_name(self):
         return os.environ.get("JOB_NAME")

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -7,12 +7,21 @@ import logging
 
 import aiofiles
 import yaml
+import tarfile
+import hashlib
+import shutil
+import urllib
+import json
+import requests
+import subprocess
 from errata_tool import ErrataConnector
 
 from doozerlib import assembly, model, util as doozerutil
 from pyartcd import exectools, constants
+from pyartcd.oc import get_release_image_pullspec, extract_release_binary, extract_release_client_tools
 
 logger = logging.getLogger(__name__)
+goArches = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
 
 
 def isolate_el_version_in_release(release: str) -> Optional[int]:
@@ -267,3 +276,191 @@ async def is_build_permitted(version: str, data_path: str = constants.OCP_BUILD_
 
     # Fallback to default
     return True
+
+
+def getReleaseControllerArch(releaseStreamName):
+    arch = 'amd64'
+    streamNameComponents = releaseStreamName.split('-')
+    for goArch in goArches:
+        if goArch in streamNameComponents:
+            arch = goArch
+    return arch
+
+
+def getReleaseControllerURL(releaseStreamName):
+    arch = getReleaseControllerArch(releaseStreamName)
+    return f"https://{arch}.ocp.releases.ci.openshift.org"
+
+
+def stagePublishClient(working_dir, from_release_tag, release_name, arch, client_type):
+    subprocess.run(f"docker login -u openshift-release-dev+art_quay_dev -p {os.environ['PASSWORD']} quay.io")
+    minor = release_name.split(".")[1]
+    quay_url = constants.QUAY_URL
+    # Anything under this directory will be sync'd to the mirror
+    BASE_TO_MIRROR_DIR = f"{working_dir}/to_mirror/openshift-v4"
+    shutil.rmtree(BASE_TO_MIRROR_DIR, ignore_errors=True)
+
+    # From the newly built release, extract the client tools into the workspace following the directory structure
+    # we expect to publish to mirror
+    CLIENT_MIRROR_DIR = f"{BASE_TO_MIRROR_DIR}/{arch}/clients/{client_type}/{release_name}"
+    os.makedirs(CLIENT_MIRROR_DIR)
+
+    if arch == 'x86_64':
+        # oc image  extract requires an empty destination directory. So do this before extracting tools.
+        # oc adm release extract --tools does not require an empty directory.
+        image_stat, oc_mirror_pullspec = get_release_image_pullspec(f"{quay_url}:{from_release_tag}", "oc-mirror")
+        if image_stat == 0:  # image exist
+            # extract image to workdir, if failed it will raise error in function
+            extract_release_binary(oc_mirror_pullspec, f"--path=/usr/bin/oc-mirror:{CLIENT_MIRROR_DIR}")
+            # archive file
+            with tarfile.open(f"{CLIENT_MIRROR_DIR}/oc-mirror.tar.gz", "w:gz") as tar:
+                tar.add(f"{CLIENT_MIRROR_DIR}/oc-mirror")
+            # calc shasum
+            with open(f"{CLIENT_MIRROR_DIR}/oc-mirror", 'rb') as f:
+                shasum = hashlib.sha256(f.read()).hexdigest()
+            # write shasum to sha256sum.txt
+            with open(f"{CLIENT_MIRROR_DIR}/sha256sum.txt", 'a') as f:
+                f.write(shasum)
+            # remove oc-mirror
+            os.remove(f"{CLIENT_MIRROR_DIR}/oc-mirror")
+
+    # extract release clients tools
+    extract_release_client_tools(f"{quay_url}:{from_release_tag}", f"--to={CLIENT_MIRROR_DIR}", None)
+    # create symlink for clients
+    create_symlink(CLIENT_MIRROR_DIR, False, False)
+
+    if minor > 0:
+        try:
+            # To encourage customers to explore dev-previews & pre-GA releases, populate changelog
+            # https://issues.redhat.com/browse/ART-3040
+            prevMinor = minor - 1
+            rcURL = getReleaseControllerURL(release_name)
+            rcArch = getReleaseControllerArch(release_name)
+            stableStream = "4-stable" if rcArch == "amd64" else f"4-stable-{rcArch}"
+            outputDest = f"{CLIENT_MIRROR_DIR}/changelog.html"
+            outputDestMd = f"{CLIENT_MIRROR_DIR}/changelog.md"
+
+            # If the previous minor is not yet GA, look for the latest fc/rc/ec. If the previous minor is GA, this should
+            # always return 4.m.0.
+            url = 'https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest'
+            full_url = f"{url}?{urllib.parse.urlencode({'in': f'=>4.{prevMinor}.0-0 <4.{prevMinor}.1'})}"
+            with urllib.request.urlopen(full_url) as response:
+                data = json.load(response)
+            prevGA = data['name']
+            # See if the previous minor has GA'd yet; e.g. https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.8.0
+            check = requests.get(f"{rcURL}/releasestream/{stableStream}/release/{prevGA}", timeout=30)
+            if check.status_code == 200:
+                # If prevGA is known to the release controller, compute the changelog html
+                response = requests.get(f"{rcURL}/changelog?from={prevGA}&to={release_name}&format=html", timeout=180)
+                with open(outputDest, 'w') as f:
+                    f.write(response.text)
+                # Also collect the output in markdown for SD to consume
+                response = requests.get(f"{rcURL}/changelog?from={prevGA}&to={release_name}", timeout=180)
+                with open(outputDestMd, 'w') as f:
+                    f.write(response.text)
+            else:
+                with open(outputDest, 'w') as f:
+                    f.write(f"<html><body><p>Changelog information cannot be computed for this release. Changelog information will be populated for new releases once {prevGA} is officially released.</p></body></html>")
+                with open(outputDestMd, 'w') as f:
+                    f.write(f"Changelog information cannot be computed for this release. Changelog information will be populated for new releases once {prevGA} is officially released.")
+        except Exception as e:
+            logger.error("Error generating changelog for release")
+            raise e
+
+    # extract opm binaries
+    operator_registry = get_release_image_pullspec(f"{quay_url}:{from_release_tag}", "operator-registry")
+    binaries = ['opm']
+    platforms = ['linux']
+    if arch == 'x86_64':  # For x86_64, we have binaries for macOS and Windows
+        binaries += ['darwin-amd64-opm', 'windows-amd64-opm']
+        platforms += ['mac', 'windows']
+    path_args = []
+    for binary in binaries:
+        path_args.append(f'--path=/usr/bin/registry/{binary}:{CLIENT_MIRROR_DIR}')
+    extract_release_binary(operator_registry, path_args)
+    # Compress binaries into tar.gz files and calculate sha256 digests
+    os.chdir(CLIENT_MIRROR_DIR)
+    for idx, binary in enumerate(binaries):
+        platform = platforms[idx]
+        os.chmod(binary, 0o755)
+        with tarfile.open(f"opm-{platform}-{release_name}.tar.gz", "w:gz") as tar:  # archive file
+            tar.add(binary)
+        os.remove(binary)  # remove oc-mirror
+        os.symlink(f'opm-{platform}-{release_name}.tar.gz', f'opm-{platform}.tar.gz')  # create symlink
+        with open(binary, 'rb') as f:  # calc shasum
+            shasum = hashlib.sha256(f.read()).hexdigest()
+        with open("sha256sum.txt", 'a') as f:  # write shasum to sha256sum.txt
+            f.write(shasum)
+
+    print_dir_tree(CLIENT_MIRROR_DIR)  # print dir tree
+    print_file_content(f"{CLIENT_MIRROR_DIR}/sha256sum.txt")  # print sha256sum.txt
+
+    # Publish the clients to our S3 bucket.
+    subprocess.run(f"aws s3 sync --no-progress --exact-timestamps {BASE_TO_MIRROR_DIR}/ s3://art-srv-enterprise/pub/openshift-v4/", shell=True, check=True)
+
+
+def stagePublishMultiClient(working_dir, from_release_tag, release_name, client_type):
+    subprocess.run(f"docker login -u openshift-release-dev+art_quay_dev -p {os.environ['PASSWORD']} quay.io")
+    # Anything under this directory will be sync'd to the mirror
+    BASE_TO_MIRROR_DIR = f"{working_dir}/to_mirror/openshift-v4"
+    shutil.rmtree(BASE_TO_MIRROR_DIR, ignore_errors=True)
+    RELEASE_MIRROR_DIR = f"{BASE_TO_MIRROR_DIR}/multi/clients/{client_type}/{release_name}"
+
+    for goArch in goArches:
+        if goArch == "multi":
+            continue
+        # From the newly built release, extract the client tools into the workspace following the directory structure
+        # we expect to publish to mirror
+        CLIENT_MIRROR_DIR = f"{RELEASE_MIRROR_DIR}/{goArch}"
+        os.makedirs(CLIENT_MIRROR_DIR)
+        # extract release clients tools
+        extract_release_client_tools(f"{constants.QUAY_URL}:{from_release_tag}", f"--to={CLIENT_MIRROR_DIR}", goArch)
+        # create symlink for clients
+        create_symlink(CLIENT_MIRROR_DIR, True, True)
+
+    # Create a master sha256sum.txt including the sha256sum.txt files from all subarches
+    # This is the file we will sign -- trust is transitive to the subarches
+    subprocess.run(f"cd {RELEASE_MIRROR_DIR};sha256sum */sha256sum.txt > {RELEASE_MIRROR_DIR}/sha256sum.txt", shell=True, check=True)
+
+    # Publish the clients to our S3 bucket.
+    subprocess.run(f"aws s3 sync --no-progress --exact-timestamps {BASE_TO_MIRROR_DIR}/ s3://art-srv-enterprise/pub/openshift-v4/", shell=True, check=True)
+
+
+def print_dir_tree(path_to_dir):
+    for child in os.listdir(path_to_dir):
+        child_path = os.path.join(path_to_dir, child)
+        logger.info(child_path)
+
+
+def print_file_content(path_to_file):
+    with open(path_to_file, 'r') as f:
+        logger.info(f.read())
+
+
+def create_symlink(path_to_dir, print_tree, print_file):
+    # External consumers want a link they can rely on.. e.g. .../latest/openshift-client-linux.tgz .
+    # So whatever we extract, remove the version specific info and make a symlink with that name.
+    for f in os.listdir(path_to_dir):
+        if f.endswith(('.tar.gz', '.bz', '.zip', '.tgz')):
+            # Is this already a link?
+            if os.path.islink(f):
+                continue
+            # example file names:
+            #  - openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+            #  - openshift-client-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+            #  - openshift-install-mac-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+            #  - openshift-client-linux-4.1.9.tar.gz
+            #  - openshift-install-mac-4.3.0-0.nightly-s390x-2020-01-06-081137.tar.gz
+            #  ...
+            # So, match, and store in a group, any character up to the point we find -DIGIT. Ignore everything else
+            # until we match (and store in a group) one of the valid file extensions.
+            match = re.match(r'^([^-]+)((-[^0-9][^-]+)+)-[0-9].*(tar.gz|tgz|bz|zip)$', f)
+            if match:
+                new_name = match.group(1) + match.group(2) + '.' + match.group(4)
+                # Create a symlink like openshift-client-linux.tgz => openshift-client-linux-4.3.0-0.nightly-2019-12-06-161135.tar.gz
+                os.symlink(f, new_name)
+
+        if print_tree:
+            print_dir_tree(path_to_dir)  # print dir tree
+        if print_file:
+            print_file_content(f"{path_to_dir}/sha256sum.txt")  # print sha256sum.txt

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -9,6 +9,7 @@ Jinja2
 jira >= 3.4.1  # https://github.com/pycontribs/jira/issues/1486
 openshift-client
 pygit2 == 1.10.1 # https://github.com/libgit2/pygit2/issues/1176
+PyGithub >= 1.57
 rh-elliott
 rh-doozer
 ruamel.yaml

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -18,3 +18,4 @@ slack_sdk >= 3.13.0
 tenacity
 aiohttp_retry
 toml
+stomp.py


### PR DESCRIPTION
In this pr I did the following work:
- move mirror binary step into promote job
  - in this step I use openshift-client to invoke oc cli and get results, also use python lib to do the archive work and calc sha256sum
- move sign artifacts step into promote job
  - in this step I use jenkinsapi to invoke sign artifacts job
- move channel prs step into promote job
  - similar to previous step also implement with jenkinsapi, also update the build_microshift job invoke method
- move validate rhsa step into promote job
  - invoke elliott cli to do that in python
- add attach builds and check microshift bugs step in promote job
  - I update the build_microshift job it will store microshift nvrs in each build's description so nvrs can be easily get for attach and check step
  - and also update build_microshift, move the create pr step into promote job and in create pr function merge the pr after it created, so build_microshift job only do the build work 
  - invoke elliott cli to do that in python
- move send email step into promote job
  - use the send mail function in lib
- trigger microshift_sync job for EC after microshift job complete
- move sendCImessage to python
  - use stomp lib to send message

======
this pr replace the work of https://github.com/openshift/aos-cd-jobs/pull/3507 https://github.com/openshift-eng/aos-cd-jobs/pull/3553