### PR TITLE
Update tarball sources

### DIFF
--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -1,6 +1,6 @@
-PLASHET_REMOTE_URL = "http://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets"
-PLASHET_REMOTE_HOST = "ocp-build@rcm-guest.app.eng.bos.redhat.com"
-PLASHET_REMOTE_BASE_DIR = "/mnt/rcm-guest/puddles/RHAOS/plashets"
+PLASHET_REMOTE_URL = "https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets"
+PLASHET_REMOTE_HOST = "ocp-artifacts"
+PLASHET_REMOTE_BASE_DIR = "/mnt/data/pub/RHOCP/plashets"
 
 TARBALL_SOURCES_REMOTE_HOST = "ocp-build@rcm-guest.app.eng.bos.redhat.com"
 TARBALL_SOURCES_REMOTE_BASE_DIR = "/mnt/rcm-guest/ocp-client-handoff"

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -2,8 +2,8 @@ PLASHET_REMOTE_URL = "https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/R
 PLASHET_REMOTE_HOST = "ocp-artifacts"
 PLASHET_REMOTE_BASE_DIR = "/mnt/data/pub/RHOCP/plashets"
 
-TARBALL_SOURCES_REMOTE_HOST = "ocp-build@rcm-guest.app.eng.bos.redhat.com"
-TARBALL_SOURCES_REMOTE_BASE_DIR = "/mnt/rcm-guest/ocp-client-handoff"
+TARBALL_SOURCES_REMOTE_HOST = "spmm-util"
+TARBALL_SOURCES_REMOTE_BASE_DIR = "ocp-client-handoff"
 
 OPERATOR_URL = 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-sdk'
 BREW_SERVER = 'https://brewhub.engineering.redhat.com/brewhub'

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -103,7 +103,7 @@ class RebuildPipeline:
             with open(overrides_plashet_dir / "rebuild.repo", "w") as file:
                 self._generate_repo_file_for_image(file, plashets, group_config["arches"])
 
-            # Copies plashet repos out to rcm-guest
+            # Copies plashet repos out to ocp-artifacts
             await asyncio.gather(*[
                 self._copy_plashet_out_to_remote(el_version, plashet[1]) for plashet in plashets
             ])
@@ -125,7 +125,7 @@ class RebuildPipeline:
             with open(overrides_plashet_dir / "rebuild.repo", "w") as file:
                 self._generate_repo_file_for_rhcos(file, plashets)
 
-            # Copies plashet repos out to rcm-guest
+            # Copies plashet repos out to ocp-artifacts
             await asyncio.gather(*[
                 self._copy_plashet_out_to_remote(el_version, plashet[1]) for plashet in plashets
             ])
@@ -265,7 +265,7 @@ class RebuildPipeline:
         return PlashetBuildResult(name, plashet_dir, remote_url)
 
     async def _copy_plashet_out_to_remote(self, el_version: int, local_plashet_dir: os.PathLike, symlink_name: Optional[str] = None):
-        """ Copies plashet out to remote host (rcm-guest)
+        """ Copies plashet out to remote host (ocp-artifacts)
         """
         # Make sure the remote base dir exist
         major, minor = self._ocp_version

--- a/pyartcd/pyartcd/pipelines/tarball_sources.py
+++ b/pyartcd/pyartcd/pipelines/tarball_sources.py
@@ -41,7 +41,7 @@ class TarballSourcesPipeline:
         self.runtime.logger.info("Creating tarball sources for advisories %s", advisories)
         source_directory = f"{self.runtime.working_dir}/container-sources/"
         tarball_files = await self._create_tarball_sources(advisories, source_directory)
-        self.runtime.logger.info("Copying to rcm-guest")
+        self.runtime.logger.info("Copying to spmm-util")
         await self._copy_to_rcm_guest(source_directory)
         self.runtime.logger.info("Creating JIRA")
         new_issue = self._create_jira(advisories, tarball_files)

--- a/pyartcd/tests/pipelines/test_tarball_sources.py
+++ b/pyartcd/tests/pipelines/test_tarball_sources.py
@@ -16,11 +16,11 @@ Created tarball source /mnt/nfs/home/jenkins/yuxzhu/OSE-4.6-RHEL-8/84693/release
 
 All tarball sources are successfully created.
 
-To send all tarball sources to rcm-guest, run:
+To send all tarball sources to spmm-util, run:
 
-    rsync -avz --no-perms --no-owner --no-group /mnt/nfs/home/jenkins/yuxzhu/ ocp-build@rcm-guest.app.eng.bos.redhat.com:/mnt/rcm-guest/ocp-client-handoff/
+    rsync -avz --no-perms --no-owner --no-group /mnt/nfs/home/jenkins/yuxzhu/ exd-ocp-buildvm-bot-prod@spmm-util:ocp-client-handoff/
 
-Then notify RCM (https://projects.engineering.redhat.com/projects/RCM/issues) that the following tarball sources have been uploaded to rcm-guest:
+Then notify RCM (https://projects.engineering.redhat.com/projects/RCM/issues) that the following tarball sources have been uploaded to spmm-util:
 
 OSE-4.6-RHEL-8/84693/release/logging-fluentd-container-v4.6.0-202111191944.p0.gf73a1dd.assembly.stream.tar.gz
         """, "")


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-6353

`/home/jenkins/.ssh/config` has been updated with `spmm-utils` host access. The authentication is LDAP based, our service account `exd-ocp-buildvm-bot-prod` has been added to `spmm-util-users` group and can upload files to the new host. 

[According to the docs](https://spmm.pages.redhat.com/util-ansible/#migrating-from-rcm-guest), the destination path must not be absolute but relative with the old `/mnt/rcm-guest/` path references.