### PR TITLE
microshift: Support publishing RCs to mirror

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -129,8 +129,8 @@ class BuildMicroShiftPipeline:
                 message += f"\nA PR to update the assembly definition has been created/updated: {pr.html_url}"
                 message += "\nReview and merge the PR before you proceed.\n"
             message += f"\nTo attach the build to Errata, run <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fprepare-release/|prepare-release> job or `elliott --group {self.group} --assembly {self.assembly} --rpms microshift find-builds -k rpm --member-only --use-default-advisory microshift`."
-            if assembly_type is AssemblyTypes.PREVIEW:
-                message += "\n This is an EC release. Please run <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fmicroshift_sync/|microshift_sync> with `UPDATE_PUB_MIRROR` checked."
+            if assembly_type in [AssemblyTypes.PREVIEW, AssemblyTypes.CANDIDATE]:
+                message += f"\n This is a {assembly_type.name} release. Please run <https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fmicroshift_sync/|microshift_sync> to publish the build to mirror."
             if slack_client:
                 await slack_client.say(message, slack_thread)
         except Exception as err:


### PR DESCRIPTION
Currently we only publish ECs to mirror. MicroShift team requests to publish RCs as well. Note it is agreed to continue to use the ART key to sign RC builds.