### PR TITLE
ART-5660 Determine rhcos stream from group config

### DIFF
--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -92,7 +92,7 @@ node {
                         text = sh(returnStdout: true, script: """
                               no_proxy=api.ocp-virt.prod.psi.redhat.com,\$no_proxy \\
                               artcd ${dryrun} --config=./config/artcd.toml build-rhcos --version=${params.BUILD_VERSION} \\
-                              --ignore-running=${params.IGNORE_RUNNING} --new-build=${params.NEW_BUILD}
+                                --ignore-running=${params.IGNORE_RUNNING} --new-build=${params.NEW_BUILD}
                         """)
                         echo text
                         if (params.DRY_RUN) {

--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -39,6 +39,11 @@ node {
                         description: '(Multi pipeline only) Request a build from the RHCOS pipeline even if one is already in progress (instead of aborting like usual). Still only one runs at a time. Only for use by humans, really, and you probably want NEW_BUILD with this.',
                         defaultValue: false,
                     ),
+                    booleanParam(
+                        name: "DRY_RUN",
+                        description: "Take no action, just echo what the job would have done.",
+                        defaultValue: false
+                    ),
                 ]
             ],
         ]
@@ -65,7 +70,8 @@ node {
         // Disabling compose lock for now. Ideally we achieve a stable repo for RHCOS builds in the future,
         // but for now, being this strict is slowing down the delivery of nightlies.
         //lock("compose-lock-${params.BUILD_VERSION}") {
-        lock(resource: "rhcos-lock-${params.BUILD_VERSION}", skipIfLocked: true) {  // wait for all to succeed or fail for this version before starting more
+        def lockval = params.DRY_RUN ? "rhcos-lock-${params.BUILD_VERSION}-dryrun" : "rhcos-lock-${params.BUILD_VERSION}"
+        lock(resource: lockval, skipIfLocked: true) {  // wait for all to succeed or fail for this version before starting more
             skipBuild = false
 
             // Check if urls.rhcos_release_base.multi is defined in group.yml
@@ -78,15 +84,21 @@ node {
                 def jenkins_url = 'https://jenkins-rhcos.apps.ocp-virt.prod.psi.redhat.com'
                 commonlib.shell(script: "pip install -e ./pyartcd && rm -rf ./artcd_working && mkdir -p ./artcd_working")
 
+                def dryrun = params.DRY_RUN ? '--dry-run' : ''
                 def run_multi_build = {
                     withCredentials([file(credentialsId: kubeconfigs['multi'], variable: 'KUBECONFIG')]) {
                         // we want to see the stderr as it runs, so will not capture with commonlib.shell;
                         // but somehow it is buffering the stderr anyway and [lmeyer] cannot figure out why.
                         text = sh(returnStdout: true, script: """
                               no_proxy=api.ocp-virt.prod.psi.redhat.com,\$no_proxy \\
-                              artcd --config=./config/artcd.toml build-rhcos --version=${params.BUILD_VERSION} \\
-                                    --ignore-running=${params.IGNORE_RUNNING} --new-build=${params.NEW_BUILD}
+                              artcd ${dryrun} --config=./config/artcd.toml build-rhcos --version=${params.BUILD_VERSION} \\
+                              --ignore-running=${params.IGNORE_RUNNING} --new-build=${params.NEW_BUILD}
                         """)
+                        echo text
+                        if (params.DRY_RUN) {
+                            skipBuild = true
+                            return
+                        }
                         data = readJSON text: text
                         if (data["action"] == "skip") {
                             skipBuild = true

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence
 
 from pyartcd.cli import cli
 from pyartcd.pipelines import (
-    check_bugs, gen_assembly, promote, rebuild, report_rhcos,
+    build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync
 )
 

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence
 
 from pyartcd.cli import cli
 from pyartcd.pipelines import (
-    build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
+    check_bugs, gen_assembly, promote, rebuild, report_rhcos,
     review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync
 )
 

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -129,7 +129,13 @@ class BuildRhcosPipeline:
             "urls.rhcos_release_base.multi",
             "--default ''"
         ]
-        _, stdout, _ = await exectools.cmd_gather_async(cmd, stderr=None)
+        _LOGGER.info("Running command: %s", cmd)
+        result = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, check=False, universal_newlines=True)
+        if result.returncode != 0:
+            raise IOError(
+                f"Command {cmd} returned {result.returncode}: stdout={result.stdout}, stderr={result.stderr}"
+            )
+        _LOGGER.info(result.stdout)
         match = re.search(r'streams/(.*)/builds', stdout)
         if match:
             self._stream = match[1]

--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -202,7 +202,7 @@ class BuildRhcosPipeline:
                 if spec not in new_builds_seen and spec not in completed_builds:
                     completed_builds[spec] = completed = self.build_result(*spec)
                     if completed:  # silently ignore if it's somehow not there... should never happen
-                        _LOGGER.info(f"{completed['url']} finished with {completed['result']}: '{completed['description']}'")
+                        print(f"{completed['url']} finished with {completed['result']}: '{completed['description']}'", file=sys.stderr)
 
             # if there are no builds left running, we're done
             if not new_builds_seen:
@@ -212,9 +212,9 @@ class BuildRhcosPipeline:
             for spec, description in new_builds_seen.items():
                 job, number = spec
                 if spec not in builds_seen:
-                    _LOGGER.info(f"New build #{number} of {job} job: {self.build_url(job, number)}")
+                    print(f"New build #{number} of {job} job: {self.build_url(job, number)}", file=sys.stderr)
                 elif description != builds_seen[spec]:
-                    _LOGGER.info(f"Build #{number} of {job} job update: '{description}'")
+                    print(f"Build #{number} of {job} job update: '{description}'", file=sys.stderr)
 
             builds_seen = new_builds_seen
             time.sleep(10)


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/aos-cd-jobs/pull/3564/files
Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frhcos/53/console

`Would've started build at url=https://jenkins-rhcos.apps.ocp-virt.prod.psi.redhat.com/job/build/buildWithParameters with params={'STREAM': '4.14-9.2', 'EARLY_ARCH_JOBS': 'false'}`