### PR TITLE
Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -1,6 +1,10 @@
 name: Snyk Scan
 
-on: [ push, pull_request ]
+on:
+  push: { }
+  pull_request_target:
+    types: [ opened ]
+    if: github.actor in ['jupierce', 'sosiouxme', 'thiagoalessio', 'joepvd', 'thegreyd', 'vfreex', 'locriandev', 'Ximinhan', 'ashwindasr']
 
 jobs:
   snyk:


### PR DESCRIPTION
GitHub Actions run when a PR is raised, should use the SYNK_TOKEN from the base repo instead of the forked repo. This is achieved by using `pull_request_target` instead of `pull_request` event.  Also making sure that this action runs only for authorized users.