### PR TITLE
[accept-release] Add multi as supported arch

### DIFF
--- a/jobs/build/accept-release/Jenkinsfile
+++ b/jobs/build/accept-release/Jenkinsfile
@@ -28,8 +28,8 @@ node {
                     ),
                     choice(
                         name: 'ARCH',
-                        description: 'Release architecture (amd64, s390x, ppc64le, arm64)',
-                        choices: ['amd64', 's390x', 'ppc64le', 'arm64'].join('\n'),
+                        description: 'Release architecture (amd64, s390x, ppc64le, arm64, multi)',
+                        choices: ['amd64', 's390x', 'ppc64le', 'arm64', 'multi'].join('\n'),
                     ),
                     booleanParam(
                         name: 'REJECT',


### PR DESCRIPTION
Add 'multi' arch which is supported by the script we're using
https://raw.githubusercontent.com/openshift/release-controller/master/hack/release-tool.py