### PR TITLE
[promote-assembly] Fix - use arch from release_info

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -228,9 +228,8 @@ node {
             if (release_info.type == 'candidate' || release_info.type == 'standard') {
                 def src_output_dir = "${WORKSPACE}/rhcos_src_staging"
                 sh "rm -rf ${src_output_dir}"
-                for (arch in arches) {
-                    arch = commonlib.brewArchForGoArch(arch)
-                    def rhcos_build = release_info.content[arch].rhcos_version
+                release_info.content.each { arch, info ->
+                    def rhcos_build = info.rhcos_version
                     buildlib.doozer("--group openshift-${major}.${minor} --assembly ${params.ASSEMBLY} config:rhcos-srpms --version ${rhcos_build} --arch ${arch} -o ${src_output_dir}")
                 }
                 commonlib.syncDirToS3Mirror("${src_output_dir}/", "/pub/openshift-v4/sources/packages/", delete_old=false)

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -229,8 +229,10 @@ node {
                 def src_output_dir = "${WORKSPACE}/rhcos_src_staging"
                 sh "rm -rf ${src_output_dir}"
                 release_info.content.each { arch, info ->
-                    def rhcos_build = info.rhcos_version
-                    buildlib.doozer("--group openshift-${major}.${minor} --assembly ${params.ASSEMBLY} config:rhcos-srpms --version ${rhcos_build} --arch ${arch} -o ${src_output_dir}")
+                    if (arch != "multi") {
+                        def rhcos_build = info.rhcos_version
+                        buildlib.doozer("--group openshift-${major}.${minor} --assembly ${params.ASSEMBLY} config:rhcos-srpms --version ${rhcos_build} --arch ${arch} -o ${src_output_dir}")
+                    }
                 }
                 commonlib.syncDirToS3Mirror("${src_output_dir}/", "/pub/openshift-v4/sources/packages/", delete_old=false)
             }


### PR DESCRIPTION
Fix `arches` not found error - https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote-assembly/664/console

[Hack space run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fpromote-assembly/10/console)