### PR TITLE
update 4.13 rhcos meta url

### DIFF
--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -37,6 +37,9 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(ocpVersion)
     if (major > 4 || (major == 4 && minor >=9)) {
         baseUrl = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/$ocpVersion/builds/$rhcosBuild/$arch"
+        if (minor >= 13) {
+            baseUrl = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/$ocpVersion-9.2/builds/$rhcosBuild/$arch"
+        }
     }
     s3MirrorBaseDir = "/pub/openshift-v4/${arch}/dependencies/rhcos"
     // Actual meta.json


### PR DESCRIPTION
4.12 use `4.13-9.2` instead of `4.13` in URL
test build: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ximhan/job/build%252Frhcos_sync/3/console