### PR TITLE
poll-payload: Trigger jobs for 4.14

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -18,15 +18,14 @@ import groovy.json.JsonOutput
     "4-dev-preview-ppc64le": [this.&setDevPreviewLatest],
     "4-dev-preview-arm64": [this.&setDevPreviewLatest],
 
-    "4.13.0-0.nightly":  [this.&startBuildMicroshiftJob],
+    "4.14.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.14.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
 
-    "4.12.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMs],
-    "4.12.0-0.nightly-arm64": [this.&publishRPMs],
-    "4.12.0-0.nightly-multi": [this.&startPreReleaseJob],
-    // 4.11 is not going to be released as a fc/rc named release, so
-    // continue to publish as dev-preview until all 4.11 heterogeneous
-    // users are using named releases.
-    "4.11.0-0.nightly-multi": [this.&startPreReleaseJob],
+    "4.13.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.13.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+
+    "4.12.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl8],
+    "4.12.0-0.nightly-arm64": [this.&publishRPMsEl8],
 ]
 
 def setDevPreviewLatest(String releaseStream, Map latestRelease, Map previousRelease) {
@@ -50,7 +49,7 @@ def startPreReleaseJob(String releaseStream, Map latestRelease, Map previousRele
     )
 }
 
-def publishRPMs(String releaseStream, Map latestRelease, Map previousRelease) {
+def publishRPMsEl9(String releaseStream, Map latestRelease, Map previousRelease) {
     def buildVersion = commonlib.extractMajorMinorVersion(releaseStream)
     def arch = commonlib.extractArchFromReleaseName(latestRelease.name)
     build(
@@ -58,6 +57,20 @@ def publishRPMs(String releaseStream, Map latestRelease, Map previousRelease) {
         parameters: [
             string(name: 'BUILD_VERSION', value: buildVersion),
             string(name: 'ARCH', value: arch),
+            string(name: 'EL_VERSION', value: '9'),
+        ],
+    )
+}
+
+def publishRPMsEl8(String releaseStream, Map latestRelease, Map previousRelease) {
+    def buildVersion = commonlib.extractMajorMinorVersion(releaseStream)
+    def arch = commonlib.extractArchFromReleaseName(latestRelease.name)
+    build(
+        job: '/aos-cd-builds/build%2Fpublish-rpms',
+        parameters: [
+            string(name: 'BUILD_VERSION', value: buildVersion),
+            string(name: 'ARCH', value: arch),
+            string(name: 'EL_VERSION', value: '8'),
         ],
     )
 }


### PR DESCRIPTION
- Trigger build-microshift and publish-rpms for 4.14.
- Stop trigger pre-release job for old releases.