### PR TITLE
promote: Fix string extrapolation

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -502,21 +502,21 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
     sh "mkdir -p ${CLIENT_MIRROR_DIR}"
 
     // Find the GitHub commit id for cli and download the repo at that commit, then publish it.
-    def download_cli_tarball = '''
+    def download_cli_tarball = """
         if oc adm release info ${quay_url}:${from_release_tag} --image-for=cli ; then
-            commit=$(oc image info --output json `oc adm release info ${quay_url}:${from_release_tag} --image-for=cli` | jq -r '.config.config.Labels."io.openshift.build.commit.id"')
+            commit=\$(oc image info --output json `oc adm release info ${quay_url}:${from_release_tag} --image-for=cli` | jq -r '.config.config.Labels."io.openshift.build.commit.id"')
             pushd ${CLIENT_MIRROR_DIR}
             curl -L -o "oc-source.tar.gz" https://github.com/openshift/oc/archive/${commit}.tar.gz
             sha256sum oc-source.tar.gz >> sha256sum.txt
             popd
         fi
-    '''
+    """
     commonlib.shell(script: download_cli_tarball)
 
     if ( arch == 'x86_64' ) {
         // oc image  extract requires an empty destination directory. So do this before extracting tools.
         // oc adm release extract --tools does not require an empty directory.
-        def oc_mirror_extract_cmd = '''
+        def oc_mirror_extract_cmd = """
             # If the release payload contains an oc-mirror artifact image, then extract the oc-mirror binary.
             if oc adm release info ${quay_url}:${from_release_tag} --image-for=oc-mirror ; then
                 MOBY_DISABLE_PIGZ=true GOTRACEBACK=all oc image extract `oc adm release info ${quay_url}:${from_release_tag} --image-for=oc-mirror` --path /usr/bin/oc-mirror:${CLIENT_MIRROR_DIR}
@@ -526,7 +526,7 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
                 rm oc-mirror
                 popd
             fi
-        '''
+        """
         commonlib.shell(script: oc_mirror_extract_cmd)
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/openshift-eng/aos-cd-jobs/pull/3607

We need the `"""` to have string extrapolation, but need to escape the legit `$` to not have groovy barf on the sub shell.