### PR TITLE
prepare-release: Fix INCLUDE_SHIPPED parameter

### DIFF
--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -117,7 +117,7 @@ node {
                     cmd << "--default-advisories"
                 }
                 if (params.INCLUDE_SHIPPED) {
-                    cmd << "--include_shipped"
+                    cmd << "--include-shipped"
                 }
                 if (params.PACKAGE_OWNER)
                     cmd << "--package-owner" << params.PACKAGE_OWNER


### PR DESCRIPTION
prepare-release: fix INCLUDE_SHIPPED

```
Error: No such option: --include_shipped Did you mean --include-shipped?
```

The flag should be --include-shipped instead of --include_shipped.