### PR TITLE
covscan: Fix a reposync issue

### DIFF
--- a/jobs/scanning/covscan-images/Jenkinsfile
+++ b/jobs/scanning/covscan-images/Jenkinsfile
@@ -120,10 +120,10 @@ enabled_metadata=1
                             lock('buildvm2-yum') { // Don't use yum while a job like reposync is
                                 // download the repo contents and create local repositories
                                 if ( params.REBUILD_REPOS ) {
-                                    sh "rm -rf ${prefix}_repos /var/tmp/yum-covscan"
+                                    sh "rm -rf ${prefix}_repos /var/tmp/yum-covscan-${rhel_version}"
                                     sh "sudo yum clean metadata"
                                 }
-                                sh "reposync --cachedir=/var/tmp/yum-covscan -c ${repo_fn} -a x86_64 -d -p ${prefix}_repos -n -r covscan -r covscan-testing"
+                                sh "reposync --cachedir=/var/tmp/yum-covscan-${rhel_version} -c ${repo_fn} -a x86_64 -d -p ${prefix}_repos -n -r covscan -r covscan-testing"
                                 sh "createrepo_c ${prefix}_repos/covscan"
                                 sh "createrepo_c ${prefix}_repos/covscan-testing"
                             }
@@ -267,4 +267,3 @@ enabled_metadata=1
         }
     }
 }
-


### PR DESCRIPTION
We may see the following message when running `reposync` in covscan-images job:

```
19:42:11  Not using downloaded covscan/repomd.xml because it is older than what we have:
19:42:11    Current   : Tue Mar 28 14:04:51 2023
19:42:11    Downloaded: Tue Dec 20 13:20:17 2022
```

(from https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/scanning/job/scanning%252Fcovscan-images/28/console)

This is because we use the same cache directory for rhel 7, 8, and 9 repos. This can be solved by using separate cache directories.