### PR TITLE
fix arm sdk binary path

### DIFF
--- a/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
+++ b/pyartcd/pyartcd/pipelines/operator_sdk_sync.py
@@ -83,7 +83,8 @@ class OperatorSDKPipeline:
         self.exec_cmd(cmd)
         if arch == 'amd64' or arch == 'arm64':
             tarballFilename = f"{self.sdk}-{sdkVersion}-darwin-{rarch}.tar.gz"
-            cmd = f"oc image extract {constants.OPERATOR_URL}@{shasum} --path /usr/share/{self.sdk}/mac/{self.sdk}:./{rarch}/ --confirm" + \
+            share_path = "mac_arm64" if arch == 'arm64' else "mac"
+            cmd = f"oc image extract {constants.OPERATOR_URL}@{shasum} --path /usr/share/{self.sdk}/{share_path}/{self.sdk}:./{rarch}/ --confirm" + \
                   f" && chmod +x ./{rarch}/{self.sdk} && tar -c --preserve-order -z -v --file ./{rarch}/{tarballFilename} ./{rarch}/{self.sdk}" + \
                   f" && ln -s {tarballFilename} ./{rarch}/{self.sdk}-darwin-{rarch}.tar.gz && rm -f ./{rarch}/{self.sdk}"
             self.exec_cmd(cmd)


### PR DESCRIPTION
for arm arch the build path is `/usr/share/operator-sdk/mac_arm64/operator-sdk `
ref: https://issues.redhat.com/browse/ART-6527?focusedId=22094805&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22094805