### PR TITLE
Port olm-bundle job to Python

### DIFF
--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -103,6 +103,7 @@ pipeline {
                 }
             }
         }
+
         stage('Set build info') {
             steps {
                 script {
@@ -117,46 +118,64 @@ pipeline {
                 }
             }
         }
+
         stage('Build bundles') {
             steps {
                 script {
-                    lock("olm_bundle-${params.BUILD_VERSION}") {
-                        def cmd = ""
-                        cmd += "--data-path=${params.DOOZER_DATA_PATH}"
-                        if (only)
-                            cmd += " --images=${only.join(',')}"
-                        if (exclude)
-                            cmd += " --exclude=${exclude.join(',')}"
-                        cmd += " olm-bundle:rebase-and-build"
-                        if (params.FORCE_BUILD)
-                            cmd += " --force"
-                        if (params.DRY_RUN)
-                            cmd += " --dry-run"
-                        cmd += " -- "
-                        cmd += operator_nvrs.join(' ')
+                    // Prepare working dirs
+                    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                    def doozer_working = "${WORKSPACE}/doozer_working"
+                    buildlib.cleanWorkdir(doozer_working)
 
-                        def doozer_working = "${WORKSPACE}/doozer_working"
-                        buildlib.cleanWorkdir(doozer_working)
-                        def groupParam = "openshift-${params.BUILD_VERSION}"
-                        if (doozer_data_gitref) {
-                            groupParam += "@${params.DOOZER_DATA_GITREF}"
-                        }
-                        def doozer_opts = "--working-dir ${doozer_working} -g '${groupParam}'"
-
-                        timeout(activity: true, time: 60, unit: 'MINUTES') { // if there is no log activity for 1 hour
-                            buildlib.doozer("${doozer_opts} ${cmd}")
-                            def record_log = buildlib.parse_record_log(doozer_working)
-                            def records = record_log.get('build_olm_bundle', [])
-                            def bundle_nvrs = []
-                            for (record in records) {
-                                if (record['status'] != '0') {
-                                    throw new Exception("record.log includes unexpected build_olm_bundle record with error message: ${record['message']}")
-                                }
-                                bundle_nvrs << record["bundle_nvr"]
-                            }
-                        }
+                    // Create artcd command
+                    def cmd = [
+                        "artcd",
+                        "-v",
+                        "--working-dir=./artcd_working",
+                        "--config=./config/artcd.toml",
+                    ]
+                    if (params.DRY_RUN) {
+                        cmd << "--dry-run"
                     }
-                    echo "Successfully built:\n${bundle_nvrs.join('\n')}"
+                    cmd += [
+                        "olm-bundle",
+                        "--version=${params.BUILD_VERSION}",
+                        "--assembly=${params.ASSEMBLY}",
+                        "--data-path=${params.DOOZER_DATA_PATH}",
+                        "--data-gitref=${params.DOOZER_DATA_GITREF}"
+                    ]
+                    if (operator_nvrs)
+                        cmd << "--nvrs=${operator_nvrs.join(',')}"
+                    if (only)
+                        cmd << "--only=${only.join(',')}"
+                    if (exclude)
+                        cmd << "--exclude=${exclude.join(',')}"
+                    if (params.FORCE_BUILD)
+                        cmd << "--force"
+
+                    // Run pipeline
+                    timeout(activity: true, time: 60, unit: 'MINUTES') { // if there is no log activity for 1 hour
+                        echo "Will run ${cmd}"
+                        withCredentials([
+                                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                                    string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
+                                    string(credentialsId: 'redis-port', variable: 'REDIS_PORT')
+                                ]) {
+                            sh(script: cmd.join(' '), returnStdout: true)
+                        }
+
+                        // Parse doozer record.log
+                        def record_log = buildlib.parse_record_log(doozer_working)
+                        def records = record_log.get('build_olm_bundle', [])
+                        def bundle_nvrs = []
+                        for (record in records) {
+                            if (record['status'] != '0') {
+                                throw new Exception("record.log includes unexpected build_olm_bundle record with error message: ${record['message']}")
+                            }
+                            bundle_nvrs << record["bundle_nvr"]
+                        }
+                        echo "Successfully built:\n${bundle_nvrs.join('\n')}"
+                    }
                 }
             }
         }
@@ -167,7 +186,6 @@ pipeline {
                 commonlib.safeArchiveArtifacts([
                     "doozer_working/*.log",
                     "doozer_working/*.yaml",
-                    "doozer_working/brew-logs/**",
                 ])
             }
         }

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
-    review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync
+    review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync, olm_bundle
 )
 
 

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -1,0 +1,20 @@
+from string import Template
+
+
+# Redis instance where lock are stored
+redis = Template('redis://:${redis_password}@${redis_host}:${redis_port}')
+
+# This constant defines a timeout for each kind of lock, after which the lock will expire and clear itself
+LOCK_TIMEOUTS = {
+    'olm-bundle': 60*60*2, # 2 hours
+}
+
+# This constant defines how many times the lock manager should try to acquire the lock before giving up;
+# it also defines the sleep interval between two consecutive retries, in seconds
+RETRY_POLICY = {
+    # olm-bundle: give up after 1 hour
+    'olm_bundle': {
+        'retry_count': 36000,
+        'retry_delay_min': 0.1
+    }
+}

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -1,12 +1,14 @@
+import os
 from string import Template
 
+from aioredlock import Aioredlock
 
 # Redis instance where lock are stored
-redis = Template('redis://:${redis_password}@${redis_host}:${redis_port}')
+redis = Template('${protocol}://:${redis_password}@${redis_host}:${redis_port}')
 
 # This constant defines a timeout for each kind of lock, after which the lock will expire and clear itself
 LOCK_TIMEOUTS = {
-    'olm-bundle': 60*60*2, # 2 hours
+    'olm-bundle': 60*60*2,  # 2 hours
 }
 
 # This constant defines how many times the lock manager should try to acquire the lock before giving up;
@@ -18,3 +20,36 @@ RETRY_POLICY = {
         'retry_delay_min': 0.1
     }
 }
+
+
+def new_lock_manager(internal_lock_timeout=10.0, retry_count=3, retry_delay_min=0.1, use_ssl=True):
+    """
+    Builds and returns a new aioredlock.Aioredlock instance. Requires following env vars to be defined:
+    - REDIS_SERVER_PASSWORD: authentication token to the Redis server
+    - REDIS_HOST: hostname where Redis is deployed
+    - REDIS_PORT: port where Redis is exposed
+
+    If use_ssl is set, we assume Redis server is using a secure connection, and the protocol will be rediss://
+    Otherwise, it will fall back to the unsecure redis://
+
+    lock_timeout represents the "expiration date" of all the locks instantiated on this LockManager instance.
+    If not set, it defaults to the library default
+
+    retry_count is the number of attempts to acquire the lock. Once exceeded, the lock operation will throw an Exception
+    retry_delay is the delay time in seconds between two consecutive attempts to acquire a resource
+
+    Altogether, if the resource cannot be acquired in (retry_count * retry_delay), the lock operation will fail.
+    """
+
+    redis_instance = redis.substitute(
+        protocol='rediss' if use_ssl else 'redis',
+        redis_password=os.environ['REDIS_SERVER_PASSWORD'],
+        redis_host=os.environ['REDIS_HOST'],
+        redis_port=os.environ['REDIS_PORT']
+    )
+    return Aioredlock(
+        [redis_instance],
+        internal_lock_timeout=internal_lock_timeout,
+        retry_count=retry_count,
+        retry_delay_min=retry_delay_min
+    )

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -1,0 +1,87 @@
+import os
+
+import click
+from aioredlock import Aioredlock, LockError
+
+from pyartcd import constants, exectools
+from pyartcd.cli import cli, pass_runtime, click_coroutine
+from pyartcd import locks
+from pyartcd.runtime import Runtime
+
+
+@cli.command('olm-bundle')
+@click.option('--version', required=True, help='OCP version')
+@click.option('--assembly', required=True, help='Assembly name')
+@click.option('--data-path', required=False, default=constants.OCP_BUILD_DATA_URL,
+              help='ocp-build-data fork to use (e.g. assembly definition in your own fork)')
+@click.option('--data-gitref', required=False,
+              help='(Optional) Doozer data path git [branch / tag / sha] to use')
+@click.option('--nvrs', required=False,
+              help='(Optional) List **only** the operator NVRs you want to build bundles for, everything else gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
+@click.option('--only', required=False,
+              help='(Optional) List **only** the operators you want to build, everything else gets ignored.\n' 
+                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+                   'Leave empty to build all (except EXCLUDE, if defined)')
+@click.option('--exclude', required=False,
+              help='(Optional) List the operators you **don\'t** want to build, everything else gets built.\n'
+                   'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'
+                   'Leave empty to build all (or ONLY, if defined)')
+@click.option('--force', is_flag=True,
+              help='Rebuild bundle containers, even if they already exist for given operator NVRs')
+@pass_runtime
+@click_coroutine
+async def olm_bundle(runtime: Runtime, version: str, assembly: str, data_path: str, data_gitref: str,
+                     nvrs: str, only: bool, exclude: str, force: bool):
+    # Create Doozer invocation
+    cmd = [
+        'doozer',
+        f'--assembly={assembly}',
+        '--working-dir=doozer_working',
+        f'--group=openshift-{version}@${data_gitref}' if data_gitref else f'--group=openshift-{version}',
+        f'--data-path={data_path}'
+    ]
+    if only:
+        cmd.append(f'--images={only}')
+    if exclude:
+        cmd.append(f'--exclude={exclude}')
+    cmd.append('olm-bundle:rebase-and-build')
+    if force:
+        cmd.append('--force')
+    if runtime.dry_run:
+        cmd.append('--dry-run')
+    cmd.extend(
+        [
+            '--',
+            ' '.join(nvrs.split(','))
+        ]
+    )
+
+    # Create a Lock manager instance
+    redis_url = locks.redis.substitute(
+        redis_password=os.environ['REDIS_SERVER_PASSWORD'],
+        redis_host=os.environ['REDIS_HOST'],
+        redis_port=os.environ['REDIS_PORT']
+    )
+    retry_policy = locks.RETRY_POLICY['olm_bundle']
+    lock_manager = Aioredlock(
+        [redis_url],
+        internal_lock_timeout=locks.LOCK_TIMEOUTS['olm-bundle'],
+        retry_count=retry_policy['retry_count'],
+        retry_delay_min=retry_policy['retry_delay_min']
+    )
+
+    # Try to acquire olm-bundle lock for build version
+    lock_name = f'olm_bundle-{version}'
+    try:
+        runtime.logger.info('Trying to acquire lock %s', lock_name)
+        async with await lock_manager.lock(lock_name):
+            runtime.logger.info('Lock %s acquired', lock_name)
+            runtime.logger.info('Running command: %s', cmd)
+            await exectools.cmd_assert_async(cmd)
+
+    except LockError as e:
+        runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
+        raise
+
+    finally:
+        await lock_manager.destroy()

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -57,14 +57,8 @@ async def olm_bundle(runtime: Runtime, version: str, assembly: str, data_path: s
     )
 
     # Create a Lock manager instance
-    redis_url = locks.redis.substitute(
-        redis_password=os.environ['REDIS_SERVER_PASSWORD'],
-        redis_host=os.environ['REDIS_HOST'],
-        redis_port=os.environ['REDIS_PORT']
-    )
     retry_policy = locks.RETRY_POLICY['olm_bundle']
-    lock_manager = Aioredlock(
-        [redis_url],
+    lock_manager = locks.new_lock_manager(
         internal_lock_timeout=locks.LOCK_TIMEOUTS['olm-bundle'],
         retry_count=retry_policy['retry_count'],
         retry_delay_min=retry_policy['retry_delay_min']

--- a/pyartcd/requirements.txt
+++ b/pyartcd/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp[speedups] >= 3.6
 aiofiles
+aioredlock >= 0.7.3
 click
 contextvars
 errata_tool


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-3676

Test builds:
- https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/olm-bundle/34/console was started first; it acquired the lock right away and built the bundle
- https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/olm-bundle/35/console was started a few seconds later; it found the lock already acquired, and waited for it to be available before building the bundle