### PR TITLE
Fix for installer/opm source names

### DIFF
--- a/pipeline-scripts/release.groovy
+++ b/pipeline-scripts/release.groovy
@@ -546,9 +546,9 @@ def stagePublishClient(quay_url, from_release_tag, release_name, arch, client_ty
                 source_name="openshift-client"
                 ;;
               installer)
-                source_name="openshift-installer"
+                source_name="openshift-install"
                 ;;
-              operator-registry)
+              operator-framework-olm)
                 source_name="opm"
                 ;;
             esac


### PR DESCRIPTION
What should be the last fix to #3622

Looking at https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.12.13/, we need updating the outputs to match. The client one looks good.