### PR TITLE
microshift_sync: Add missing withCredentials

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -182,9 +182,11 @@ node {
                             commonlib.syncRepoToS3Mirror(mirror_src, latest_path, true, 10, dry_run)
                             // https://issues.redhat.com/browse/ART-6607 on why invalidation matters when updating
                             // existing filenames.
-                            commonlib.shell(script:"""
-                            aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${latest_path}/*"
-                            """)
+                            withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+                                commonlib.shell(script:"""
+                                aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${latest_path}/*"
+                                """)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The `aws` command is missing credentials.