### PR TITLE
Update quay image builder container to improve error handling

### DIFF
--- a/jobs/build/aws-iso-marketplace-quay-image-builder/runner-image.Dockerfile
+++ b/jobs/build/aws-iso-marketplace-quay-image-builder/runner-image.Dockerfile
@@ -7,7 +7,7 @@ USER 0
 ADD runner-image.repo /etc/yum.repos.d/
 
 RUN dnf install -y dnf-plugins-core ;\
-    dnf install -y packer git ansible-core python3-pip jq ;\
+    dnf install -y packer git ansible-core python3-pip jq skopeo ;\
     curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/oc-mirror.tar.gz | \
     tar zxv --directory /usr/bin && chmod +x /usr/bin/oc-mirror ;\
     curl -L https://github.com/mikefarah/yq/releases/download/v4.30.6/yq_linux_amd64.tar.gz | tar xzv --directory /usr/bin ;\

--- a/jobs/build/aws-iso-marketplace-quay-image-builder/runner-image.Dockerfile
+++ b/jobs/build/aws-iso-marketplace-quay-image-builder/runner-image.Dockerfile
@@ -6,13 +6,12 @@ USER 0
 
 ADD runner-image.repo /etc/yum.repos.d/
 
-RUN dnf install -y dnf-plugins-core ;\
-    dnf install -y packer git ansible-core python3-pip jq skopeo ;\
-    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/oc-mirror.tar.gz | \
-    tar zxv --directory /usr/bin && chmod +x /usr/bin/oc-mirror ;\
-    curl -L https://github.com/mikefarah/yq/releases/download/v4.30.6/yq_linux_amd64.tar.gz | tar xzv --directory /usr/bin ;\
-    mv /usr/bin/yq_linux_amd64 /usr/bin/yq ;\
-    pip3 install awscli ;\
+RUN dnf install -y dnf-plugins-core && \
+    dnf install -y packer git ansible-core python3-pip jq skopeo && \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/oc-mirror.tar.gz | tar zxv --directory /usr/bin && chmod +x /usr/bin/oc-mirror && \
+    curl -L https://github.com/mikefarah/yq/releases/download/v4.30.6/yq_linux_amd64.tar.gz | tar xzv --directory /usr/bin && \
+    mv /usr/bin/yq_linux_amd64 /usr/bin/yq && \
+    pip3 install awscli && \
     dnf clean all
 
 WORKDIR /quay-image-builder


### PR DESCRIPTION
Add skopeo to the container to allow the build script to validate the pull secret during the build.

oc-mirror latest is currently broken, switching to stable.

Combine the bash commands with `&&` so the container build exits on error instead of continuing.