### PR TITLE
Check for stream of rhcos job instead of version

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_rhcos.py
+++ b/pyartcd/pyartcd/pipelines/build_rhcos.py
@@ -130,7 +130,7 @@ class BuildRhcosPipeline:
                 if b["result"] is None  # build is still running when it has no status
             )
 
-        return [b for b in builds if b["parameters"].get("STREAM") == self.version]
+        return [b for b in builds if b["parameters"].get("STREAM") == self.stream]
 
     @property
     def stream(self):


### PR DESCRIPTION
This is tripping us - we need to check for stream(4.14-9.2) instead of version (4.14)