### PR TITLE
Port  ocp4 mirror RPMs stage to Python

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -196,7 +196,7 @@ node {
                 }
                 cmd += [
                     "ocp4:mirror-rpms",
-                    "--version=${version.full}",
+                    "--version=${version.stream}",
                     "--assembly=${params.ASSEMBLY}",
                     "--local-plashet-path=${rpmMirror.localPlashetPath}"
                 ]

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -187,8 +187,35 @@ node {
                 joblib.stageSyncImages()
             }
             stage("mirror RPMs") {
-                lock("mirroring-rpms-lock-${params.BUILD_VERSION}") {
-                    joblib.stageMirrorRpms()
+                sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+
+                // Create artcd command
+                def cmd = [
+                    "artcd",
+                    "-v",
+                    "--working-dir=./artcd_working",
+                    "--config=./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
+                    "ocp4:mirror-rpms",
+                    "--version=${version.full}",
+                    "--assembly=${params.ASSEMBLY}",
+                    "--local-plashet-path=${rpmMirror.localPlashetPath}"
+                ]
+                withCredentials([
+                            aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+                            string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                            string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
+                            string(credentialsId: 'redis-port', variable: 'REDIS_PORT')
+                        ]) {
+                    retry(3) {
+                        timeout(time: 60, unit: 'MINUTES') { // aws s3 sync has been observed to hang before
+                            sh(script: cmd.join(' '), returnStdout: true)
+                        }
+                    }
                 }
             }
             stage("sweep") {

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -400,33 +400,6 @@ def stageBuildImages() {
     }
 }
 
-/**
- * Copy the plashet created earlier out to the openshift mirrors. This allows QE to
- * easily find the RPMs we used in the creation of the images. These RPMs may be
- * required for bare metal installs.
- */
-def stageMirrorRpms() {
-    if (params.ASSEMBLY && params.ASSEMBLY != 'stream') {
-        echo "No need to mirror rpms for non-stream assembly."
-        return
-    }
-    if (!rpmMirror.localPlashetPath) {
-        echo "No updated RPMs to mirror."
-        return
-    }
-
-    def s3BaseDir = "/enterprise/enterprise-${version.stream}"
-
-    if (buildPlan.dryRun) {
-        echo "Would have copied plashet to mirror.openshift.com${s3BaseDir }"
-        return
-    }
-
-    commonlib.syncRepoToS3Mirror("${rpmMirror.localPlashetPath}/", "${s3BaseDir}/latest/") // Note s3BaseDir already has a / prefix
-    commonlib.syncRepoToS3Mirror("${rpmMirror.localPlashetPath}/", "/enterprise/all/${version.stream}/latest/")
-    echo "Finished mirroring OCP ${version.full} to openshift mirrors"
-}
-
 def stageSyncImages() {
     if (!buildPlan.buildImages) {
         echo "No built images to sync."

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -727,37 +727,6 @@ def checkS3Path(s3_path) {
     }
 }
 
-def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, dry_run=false) {
-    try {
-        checkS3Path(s3_path)
-        withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-            retry(3) {
-                timeout(time: timeout_minutes, unit: 'MINUTES') { // aws s3 sync has been observed to hang before
-                    // Sync is not transactional. If we update repomd.xml before files it references are populated,
-                    // users of the repo will get a 404. So we run in three passes:
-                    // 1. On the first pass, exclude files like repomd.xml and do not delete any old files. This ensures that we  are only adding
-                    // new rpms, filelist archives, etc.
-                    def opts = '--no-progress --exact-timestamps'
-                    if (dry_run) opts += ' --dryrun'
-                    shell(script: "aws s3 sync ${opts} --exclude '*/repomd.xml' ${local_dir} s3://art-srv-enterprise${s3_path}") // Note that s3_path has / prefix.
-                    // 2. On the second pass, include only the repomd.xml.
-                    shell(script: "aws s3 sync ${opts} --exclude '*' --include '*/repomd.xml' ${local_dir} s3://art-srv-enterprise${s3_path}")
-                    if (remove_old) {
-                        // For most repos, clean up the old rpms so they don't grow unbounded. Specify remove_old=false
-                        // to prevent this step.
-                        // Otherwise:
-                        // 3. Everything should be sync'd in a consistent way -- delete anything old with --delete.
-                        shell(script: "aws s3 sync ${opts} --delete ${local_dir} s3://art-srv-enterprise${s3_path}")
-                    }
-                }
-            }
-        }
-    } catch (e) {
-        slacklib.to("#art-release").say("Failed syncing ${local_dir} repo to art-srv-enterprise S3 path ${s3_path}")
-        throw e
-    }
-}
-
 def syncDirToS3Mirror(local_dir, s3_path, include_only='', timeout_minutes=60, delete_old=true) {
     try {
         checkS3Path(s3_path)

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -3,7 +3,8 @@ from typing import Optional, Sequence
 from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
-    review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync, olm_bundle
+    review_cvp, sweep, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
+    olm_bundle, ocp4
 )
 
 

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -19,6 +19,11 @@ RETRY_POLICY = {
     'olm_bundle': {
         'retry_count': 36000,
         'retry_delay_min': 0.1
+    },
+    # mirror RPMs: give up after 1 hour
+    'mirroring_rpms': {
+        'retry_count': 36000,
+        'retry_delay_min': 0.1
     }
 }
 

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -7,24 +7,23 @@ from aioredlock import Aioredlock
 # Redis instance where lock are stored
 redis = Template('${protocol}://:${redis_password}@${redis_host}:${redis_port}')
 
-# This constant defines a timeout for each kind of lock, after which the lock will expire and clear itself
-LOCK_TIMEOUTS = {
-    'olm-bundle': 60*60*2,  # 2 hours
-}
-
-# This constant defines how many times the lock manager should try to acquire the lock before giving up;
-# it also defines the sleep interval between two consecutive retries, in seconds
-RETRY_POLICY = {
+# This constant defines for each lock type:
+# - how many times the lock manager should try to acquire the lock before giving up
+# - the sleep interval between two consecutive retries, in seconds
+# - a timeout, after which the lock will expire and clear itself
+LOCK_POLICY = {
     # olm-bundle: give up after 1 hour
     'olm_bundle': {
         'retry_count': 36000,
-        'retry_delay_min': 0.1
+        'retry_delay_min': 0.1,
+        'lock_timeout': 60*60*2,  # 2 hours
     },
     # mirror RPMs: give up after 1 hour
     'mirroring_rpms': {
         'retry_count': 36000,
-        'retry_delay_min': 0.1
-    }
+        'retry_delay_min': 0.1,
+        'lock_timeout': 60*60*3,  # 3 hours
+    },
 }
 
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 import click
 from aioredlock import LockError
@@ -83,6 +84,7 @@ async def mirror_rpms(runtime: Runtime, version: str, assembly: str, local_plash
     except ChildProcessError as e:
         error_msg = f'Failed syncing {local_plashet_path} repo to art-srv-enterprise S3: {e}',
         runtime.logger.error(error_msg)
+        runtime.logger.error(traceback.format_exc())
         slack_client = runtime.new_slack_client()
         slack_client.bind_channel(f'openshift-{stream_version}')
         await slack_client.say(error_msg)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -1,0 +1,96 @@
+import os
+
+import click
+from aioredlock import LockError
+
+from pyartcd import exectools, locks
+from pyartcd.cli import cli, pass_runtime, click_coroutine
+from pyartcd.runtime import Runtime
+
+
+async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool):
+    if s3_path.startswith('/pub/openshift-v4/clients') or \
+            s3_path.startswith('/pub/openshift-v4/amd64') or \
+            s3_path.startswith('/pub/openshift-v4/arm64') or \
+            s3_path.startswith('/pub/openshift-v4/dependencies'):
+        raise Exception(
+            f'Invalid location on s3 ({s3_path}); these are virtual/read-only locations on the s3 '
+            'backed mirror. Qualify your path with /pub/openshift-v4/<brew_arch_name>/ instead.')
+
+    # Sync is not transactional. If we update repomd.xml before files it references are populated,
+    # users of the repo will get a 404. So we run in three passes:
+    # 1. On the first pass, exclude files like repomd.xml and do not delete any old files.
+    #    This ensures that we  are only adding new rpms, filelist archives, etc.
+    # 2. On the second pass, include only the repomd.xml.
+    base_cmd = ['aws', 's3', 'sync', '--no-progress', '--exact-timestamps']
+    if dry_run:
+        base_cmd.append('--dryrun')
+
+    cmd = base_cmd + [
+        '--exclude', '*/repomd.xml', local_dir,
+        f's3://art-srv-enterprise{s3_path}'  # Note that s3_path has / prefix.
+    ]
+    env = os.environ.copy()
+    await exectools.cmd_assert_async(cmd, env=env)
+
+    cmd = base_cmd + [
+        '--exclude', '*', '--include', '*/repomd.xml', local_dir,
+        f's3://art-srv-enterprise{s3_path}'
+    ]
+    await exectools.cmd_assert_async(cmd, env=env)
+
+
+@cli.command("ocp4:mirror-rpms",
+             help="Copy the plashet created earlier out to the openshift mirrors"
+                  "This allows QE to easily find the RPMs we used in the creation of the images."
+                  "These RPMs may be required for bare metal installs")
+@click.option('--version', required=True, help='Full OCP version, e.g. 4.14-202304181947.p?')
+@click.option('--assembly', required=True, help='Assembly name')
+@click.option('--local-plashet-path', required=False, default='', help='Local path to built plashet')
+@pass_runtime
+@click_coroutine
+async def mirror_rpms(runtime: Runtime, version: str, assembly: str, local_plashet_path: str):
+    if assembly != 'stream':
+        runtime.logger.info('No need to mirror rpms for non-stream assembly')
+        return
+
+    if not local_plashet_path:
+        runtime.logger.info('No updated RPMs to mirror.')
+        return
+
+    stream_version = version.split('-')[0]  # e.g. 4.14 from 4.14-202304181947.p?
+    s3_base_dir = f'/enterprise/enterprise-{stream_version}'
+
+    # Create a Lock manager instance
+    retry_policy = locks.RETRY_POLICY['mirroring_rpms']
+    lock_manager = locks.new_lock_manager(
+        internal_lock_timeout=locks.LOCK_TIMEOUTS['olm-bundle'],
+        retry_count=retry_policy['retry_count'],
+        retry_delay_min=retry_policy['retry_delay_min']
+    )
+    lock_name = f'mirroring-rpms-lock-{stream_version}'
+
+    # Sync plashets to mirror
+    try:
+        async with await lock_manager.lock(lock_name):
+            s3_path = f'{s3_base_dir}/latest/'
+            await sync_repo_to_s3_mirror(local_plashet_path, s3_path, runtime.dry_run)
+
+            s3_path = f'/enterprise/all/{stream_version}/latest/'
+            await sync_repo_to_s3_mirror(local_plashet_path, s3_path, runtime.dry_run)
+
+    except ChildProcessError as e:
+        error_msg = f'Failed syncing {local_plashet_path} repo to art-srv-enterprise S3: {e}',
+        runtime.logger.error(error_msg)
+        slack_client = runtime.new_slack_client()
+        slack_client.bind_channel(f'openshift-{stream_version}')
+        await slack_client.say(error_msg)
+        raise
+    except LockError as e:
+        runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
+        raise
+
+    finally:
+        await lock_manager.destroy()
+
+    runtime.logger.info('Finished mirroring OCP %s to openshift mirrors', version)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -9,7 +9,8 @@ from pyartcd.runtime import Runtime
 
 
 async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool):
-    if s3_path.startswith('/pub/openshift-v4/clients') or \
+    if not s3_path.startswith('/') or \
+            s3_path.startswith('/pub/openshift-v4/clients') or \
             s3_path.startswith('/pub/openshift-v4/amd64') or \
             s3_path.startswith('/pub/openshift-v4/arm64') or \
             s3_path.startswith('/pub/openshift-v4/dependencies'):

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -64,11 +64,11 @@ async def mirror_rpms(runtime: Runtime, version: str, assembly: str, local_plash
     s3_base_dir = f'/enterprise/enterprise-{stream_version}'
 
     # Create a Lock manager instance
-    retry_policy = locks.RETRY_POLICY['mirroring_rpms']
+    lock_policy = locks.LOCK_POLICY['mirroring_rpms']
     lock_manager = locks.new_lock_manager(
-        internal_lock_timeout=locks.LOCK_TIMEOUTS['olm-bundle'],
-        retry_count=retry_policy['retry_count'],
-        retry_delay_min=retry_policy['retry_delay_min']
+        internal_lock_timeout=lock_policy['lock_timeout'],
+        retry_count=lock_policy['retry_count'],
+        retry_delay_min=lock_policy['retry_delay_min']
     )
     lock_name = f'mirroring-rpms-lock-{stream_version}'
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -1,45 +1,12 @@
-import os
 import traceback
 
 import click
 from aioredlock import LockError
 
-from pyartcd import exectools, locks
+from pyartcd import locks
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.runtime import Runtime
-
-
-async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool):
-    if not s3_path.startswith('/') or \
-            s3_path.startswith('/pub/openshift-v4/clients') or \
-            s3_path.startswith('/pub/openshift-v4/amd64') or \
-            s3_path.startswith('/pub/openshift-v4/arm64') or \
-            s3_path.startswith('/pub/openshift-v4/dependencies'):
-        raise Exception(
-            f'Invalid location on s3 ({s3_path}); these are virtual/read-only locations on the s3 '
-            'backed mirror. Qualify your path with /pub/openshift-v4/<brew_arch_name>/ instead.')
-
-    # Sync is not transactional. If we update repomd.xml before files it references are populated,
-    # users of the repo will get a 404. So we run in three passes:
-    # 1. On the first pass, exclude files like repomd.xml and do not delete any old files.
-    #    This ensures that we  are only adding new rpms, filelist archives, etc.
-    # 2. On the second pass, include only the repomd.xml.
-    base_cmd = ['aws', 's3', 'sync', '--no-progress', '--exact-timestamps']
-    if dry_run:
-        base_cmd.append('--dryrun')
-
-    cmd = base_cmd + [
-        '--exclude', '*/repomd.xml', local_dir,
-        f's3://art-srv-enterprise{s3_path}'  # Note that s3_path has / prefix.
-    ]
-    env = os.environ.copy()
-    await exectools.cmd_assert_async(cmd, env=env)
-
-    cmd = base_cmd + [
-        '--exclude', '*', '--include', '*/repomd.xml', local_dir,
-        f's3://art-srv-enterprise{s3_path}'
-    ]
-    await exectools.cmd_assert_async(cmd, env=env)
+from pyartcd.s3 import sync_repo_to_s3_mirror
 
 
 @cli.command("ocp4:mirror-rpms",

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -1,7 +1,5 @@
-import os
-
 import click
-from aioredlock import Aioredlock, LockError
+from aioredlock import LockError
 
 from pyartcd import constants, exectools
 from pyartcd.cli import cli, pass_runtime, click_coroutine
@@ -17,7 +15,8 @@ from pyartcd.runtime import Runtime
 @click.option('--data-gitref', required=False,
               help='(Optional) Doozer data path git [branch / tag / sha] to use')
 @click.option('--nvrs', required=False,
-              help='(Optional) List **only** the operator NVRs you want to build bundles for, everything else gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
+              help='(Optional) List **only** the operator NVRs you want to build bundles for, everything else '
+                   'gets ignored. The operators should not be mode:disabled/wip in ocp-build-data')
 @click.option('--only', required=False,
               help='(Optional) List **only** the operators you want to build, everything else gets ignored.\n' 
                    'Format: Comma and/or space separated list of brew packages (e.g.: cluster-nfd-operator-container)\n'

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -52,11 +52,11 @@ async def olm_bundle(runtime: Runtime, version: str, assembly: str, data_path: s
     cmd.extend(nvrs.split(','))
 
     # Create a Lock manager instance
-    retry_policy = locks.RETRY_POLICY['olm_bundle']
+    lock_policy = locks.LOCK_POLICY['olm_bundle']
     lock_manager = locks.new_lock_manager(
-        internal_lock_timeout=locks.LOCK_TIMEOUTS['olm-bundle'],
-        retry_count=retry_policy['retry_count'],
-        retry_delay_min=retry_policy['retry_delay_min']
+        internal_lock_timeout=lock_policy['lock_timeout'],
+        retry_count=lock_policy['retry_count'],
+        retry_delay_min=lock_policy['retry_delay_min']
     )
 
     # Try to acquire olm-bundle lock for build version

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -62,9 +62,7 @@ async def olm_bundle(runtime: Runtime, version: str, assembly: str, data_path: s
     # Try to acquire olm-bundle lock for build version
     lock_name = f'olm_bundle-{version}'
     try:
-        runtime.logger.info('Trying to acquire lock %s', lock_name)
         async with await lock_manager.lock(lock_name):
-            runtime.logger.info('Lock %s acquired', lock_name)
             runtime.logger.info('Running command: %s', cmd)
             await exectools.cmd_assert_async(cmd)
 

--- a/pyartcd/pyartcd/s3.py
+++ b/pyartcd/pyartcd/s3.py
@@ -1,0 +1,45 @@
+import os
+
+from pyartcd import exectools
+
+
+async def sync_repo_to_s3_mirror(local_dir: str, s3_path: str, dry_run: bool = False, remove_old: bool = True):
+    if not s3_path.startswith('/') or \
+            s3_path.startswith('/pub/openshift-v4/clients') or \
+            s3_path.startswith('/pub/openshift-v4/amd64') or \
+            s3_path.startswith('/pub/openshift-v4/arm64') or \
+            s3_path.startswith('/pub/openshift-v4/dependencies'):
+        raise Exception(
+            f'Invalid location on s3 ({s3_path}); these are virtual/read-only locations on the s3 '
+            'backed mirror. Qualify your path with /pub/openshift-v4/<brew_arch_name>/ instead.')
+
+    full_s3_path = f's3://art-srv-enterprise{s3_path}'  # Note that s3_path has / prefix.
+
+    # Sync is not transactional. If we update repomd.xml before files it references are populated,
+    # users of the repo will get a 404. So we run in three passes:
+    # 1. On the first pass, exclude files like repomd.xml and do not delete any old files.
+    #    This ensures that we  are only adding new rpms, filelist archives, etc.
+    # 2. On the second pass, include only the repomd.xml.
+    base_cmd = ['aws', 's3', 'sync', '--no-progress', '--exact-timestamps']
+    if dry_run:
+        base_cmd.append('--dryrun')
+
+    cmd = base_cmd + [
+        '--exclude', '*/repomd.xml', local_dir, full_s3_path
+    ]
+    env = os.environ.copy()
+    await exectools.cmd_assert_async(cmd, env=env)
+
+    cmd = base_cmd + [
+        '--exclude', '*', '--include', '*/repomd.xml', local_dir, full_s3_path
+    ]
+    await exectools.cmd_assert_async(cmd, env=env)
+
+    # For most repos, clean up the old rpms so they don't grow unbounded. Specify remove_old=false to prevent this step.
+    # Otherwise:
+    # 3. Everything should be synced in a consistent way -- delete anything old with --delete.
+    if remove_old:
+        cmd = base_cmd + [
+            '--delete', local_dir, full_s3_path
+        ]
+        await exectools.cmd_assert_async(cmd, env=env)


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-3672

This is the first of many incremental changes by which we'll accomplish the full ocp4 porting. Since many locks and triggered job are involved, it felt safer to approach this task one step at the time. With this PR, `mirror RPMs` stage is ported to Python along with some groovy code currently in `commonlib`, that is used only by OCP4.

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/21/console
Synced plashets to mirror: https://s3.console.aws.amazon.com/s3/buckets/art-srv-enterprise?region=us-east-1&prefix=enterprise/all/4.7/latest/&showversions=false