### PR TITLE
custom: supply GITLAB_TOKEN for rebases

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -214,10 +214,12 @@ node {
                 command += "images:${params.IMAGE_MODE} --version v${version} --release '${release}' "
                 command += "--repo-type ${repo_type} "
                 command += "--message 'Updating Dockerfile version and release ${version}-${release}' --push "
-                if (params.IGNORE_LOCKS) {
-                     buildlib.doozer command
-                } else {
-                    lock("github-activity-lock-${params.BUILD_VERSION}") { buildlib.doozer command }
+                withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                    if (params.IGNORE_LOCKS) {
+                         buildlib.doozer command
+                    } else {
+                        lock("github-activity-lock-${params.BUILD_VERSION}") { buildlib.doozer command }
+                    }
                 }
             }
 


### PR DESCRIPTION
needed for checking schedule to enable canonical upstream looks. all other ways of running builds already do this, `custom` was missed (arguably it's not a job we need much anymore).