### PR TITLE
Remove buildlib.determineBuildVersion()

### DIFF
--- a/jobs/build/custom/Jenkinsfile
+++ b/jobs/build/custom/Jenkinsfile
@@ -137,7 +137,7 @@ node {
     def version = params.BUILD_VERSION
     def release = "?"
     if (params.IMAGE_MODE != "nothing") {
-        version = buildlib.determineBuildVersion(params.BUILD_VERSION, buildlib.getGroupBranch(doozerOpts), params.VERSION)
+        version = params.BUILD_VERSION.trim()
         release = params.RELEASE.trim() ?: buildlib.defaultReleaseFor(params.BUILD_VERSION)
     }
     // If any arch is ready for GA, use signed repos for all (plashets will sign everything).


### PR DESCRIPTION
This function is always returning 4.y ([see here](https://github.com/openshift-eng/aos-cd-jobs/blob/master/pipeline-scripts/buildlib.groovy#L1236)) and can be simplified. Verified from my hack space that `version.full` always equals `version.stream`.

Ref. https://issues.redhat.com/browse/ART-3672