### PR TITLE
Port ocp4 "build compose" stage to Python

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -154,6 +154,7 @@ node {
                     }
 
                     withCredentials([
+                            string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                             string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
                             string(credentialsId: 'redis-port', variable: 'REDIS_PORT')

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -138,22 +138,37 @@ node {
                 }
 
                 stage("build compose") {
-                    lock("compose-lock-${params.BUILD_VERSION}") {
-                        /*   Complicated conditions ahead:
-                         * - If build is not permitted: (automation is frozen, and a human did not trigger the build), isBuildPermitted will have stopped the build already
-                         * - If automation is not frozen, go ahead
-                         * - If automation is "scheduled" and job was triggered by human and there were no RPMs in the build plan: Do not build compose
-                         * - If automation is "scheduled" and job was triggered by human and there were RPMs in the build plan: Build compose, and warn
-                         */
-                        if (!(buildlib.getAutomationState(doozerOpts) in ["scheduled", "yes", "True"]) || (buildlib.getAutomationState(doozerOpts) == "scheduled" && joblib.buildPlan.buildRpms)) {
-                            joblib.stageBuildCompose()
-                        }
-                        if (buildlib.getAutomationState(doozerOpts) == "scheduled" && joblib.buildPlan.buildRpms) {
-                            slacklib.to(commonlib.extractMajorMinorVersion(params.BUILD_VERSION)).say("""
-                                *:alert: ocp4 build compose ran during automation freeze*
-                                There were RPMs in the build plan that forced build compose during automation freeze.
-                            """)
-                        }
+                    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+
+                    def cmd = [
+                        "artcd",
+                        "-v",
+                        "--working-dir=./artcd_working",
+                        "--config=./config/artcd.toml",
+                        "ocp4:build-compose",
+                        "--version=${version.stream}-${version.release}",
+                        "--assembly=${params.ASSEMBLY}"
+                    ]
+                    if (joblib.buildPlan.buildRpms) {
+                        cmd << "--build-rpms"
+                    }
+
+                    withCredentials([
+                            string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                            string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
+                            string(credentialsId: 'redis-port', variable: 'REDIS_PORT')
+                        ]) {
+                        sh(script: cmd.join(' '), returnStdout: true)
+                    }
+
+                    plashets_built = readYaml(file: "${env.WORKSPACE}/plashet-working/plashets_built.yaml")
+                    mirrorPlashet = plashets_built['rhel-server-ose-rpms']
+                    echo "mirrorPlashet: ${mirrorPlashet}"
+
+                    if(mirrorPlashet) {
+                        // public rhel7 ose plashet, if present, needs mirroring to /enterprise/ for CI
+                        rpmMirror.plashetDirName = mirrorPlashet.plashetDirName
+                        rpmMirror.localPlashetPath = mirrorPlashet.localPlashetPath
                     }
                 }
 

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -275,19 +275,6 @@ def stageBuildRpms() {
     buildPlan.dryRun ? echo("doozer ${cmd}") : buildlib.doozer(cmd)
 }
 
-/**
- * Unless no RPMs have changed, create multiple yum repos (one for each arch) of RPMs based on -candidate tags.
- * Based on commonlib.ocpReleaseState, those repos can be signed (release state) or unsigned (pre-release state).
- */
-def stageBuildCompose() {
-    def mirrorPlashet = buildlib.build_plashets(doozerOpts, version.stream, version.release, buildPlan.dryRun)['rhel-server-ose-rpms']
-    if(mirrorPlashet) {
-        // public rhel7 ose plashet, if present, needs mirroring to /enterprise/ for CI
-        rpmMirror.plashetDirName = mirrorPlashet.plashetDirName
-        rpmMirror.localPlashetPath = mirrorPlashet.localPlashetPath
-    }
-}
-
 def stageUpdateDistgit() {
     if (!buildPlan.buildImages) {
         echo "Not rebasing images."

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1320,7 +1320,6 @@ def get_owners(doozerOpts, images, rpms=[]) {
 
 def build_plashets(doozerOpts, version, release, dryRun = false) {
     def auto_signing_advisory = Integer.parseInt(doozer("${doozerOpts} -q config:read-group --default=0 signing_advisory", [capture: true]).trim())
-    def group_repos = readJSON text: doozer("${doozerOpts} -q config:read-group --default=None repos", [capture: true]).trim()
     def plashets_built = [:]
 
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -24,6 +24,12 @@ LOCK_POLICY = {
         'retry_delay_min': 0.1,
         'lock_timeout': 60*60*3,  # 3 hours
     },
+    # compose: give up after 1 hour
+    'compose': {
+        'retry_count': 36000,
+        'retry_delay_min': 0.1,
+        'lock_timeout': 60*60*6,  # 6 hours
+    },
 }
 
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -9,9 +9,6 @@ from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.runtime import Runtime
 from pyartcd.s3 import sync_repo_to_s3_mirror
 
-# Doozer working dir
-DOOZER_WORKING = 'doozer_working'
-
 
 @cli.command("ocp4:build-compose",
              help="If any RPMs have changed, create multiple yum repos (one for each arch) based on -candidate tags"

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -1,12 +1,80 @@
+
 import traceback
 
 import click
 from aioredlock import LockError
 
-from pyartcd import locks
+from pyartcd import locks, util, plashets
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.runtime import Runtime
 from pyartcd.s3 import sync_repo_to_s3_mirror
+
+# Doozer working dir
+DOOZER_WORKING = 'doozer_working'
+
+
+@cli.command("ocp4:build-compose",
+             help="If any RPMs have changed, create multiple yum repos (one for each arch) based on -candidate tags"
+                  "those repos can be signed (release state) or unsigned (pre-release state)")
+@click.option('--version', required=True, help='Full OCP version, e.g. 4.14-202304181947.p?')
+@click.option('--assembly', required=True, help='The name of an assembly to rebase & build for')
+@click.option('--build-rpms', is_flag=True, help='True if RPMs should be built')
+@pass_runtime
+@click_coroutine
+async def build_compose(runtime: Runtime, version: str, assembly: str, build_rpms: bool):
+    stream_version, release_version = version.split('-')  # e.g. (4.14, 202304181947.p?) from 4.14-202304181947.p?
+
+    # Create a Lock manager instance
+    lock_policy = locks.LOCK_POLICY['compose']
+    lock_manager = locks.new_lock_manager(
+        internal_lock_timeout=lock_policy['lock_timeout'],
+        retry_count=lock_policy['retry_count'],
+        retry_delay_min=lock_policy['retry_delay_min']
+    )
+    lock_name = f'compose-lock-{stream_version}'
+
+    # Build compose
+    try:
+        async with await lock_manager.lock(lock_name):
+            automation_state: str = await util.get_freeze_automation(stream_version)
+            runtime.logger.info('Automation state for %s: %s', stream_version, automation_state)
+
+            # - If automation is not frozen, go ahead
+            # - If automation is "scheduled" and job was triggered by human
+            #   and there were no RPMs in the build plan: Do not build compose
+            # - If automation is "scheduled" and job was triggered by human
+            #   and there were RPMs in the build plan: Build compose, and warn
+            if automation_state in ['scheduled', 'yes', 'True'] or \
+                    (automation_state in ['scheduled', 'weekdays'] and build_rpms):
+                mirror_plashet = await plashets.build_plashets(
+                    stream_version, release_version, assembly=assembly, dry_run=runtime.dry_run)
+                click.echo(mirror_plashet)
+            else:
+                runtime.logger.info('Skipping compose build')
+
+            if automation_state == 'scheduled' and build_rpms:
+                slack_client = runtime.new_slack_client()
+                slack_client.bind_channel(f'openshift-{stream_version}')
+                await slack_client.say(
+                    "*:alert: ocp4 build compose ran during automation freeze*\n"
+                    "There were RPMs in the build plan that forced build compose during automation freeze."
+                )
+
+    except ChildProcessError as e:
+        error_msg = f'Failed building compose: {e}'
+        runtime.logger.error(error_msg)
+        runtime.logger.error(traceback.format_exc())
+        slack_client = runtime.new_slack_client()
+        slack_client.bind_channel(f'openshift-{stream_version}')
+        await slack_client.say(error_msg)
+        raise
+
+    except LockError as e:
+        runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
+        raise
+
+    finally:
+        await lock_manager.destroy()
 
 
 @cli.command("ocp4:mirror-rpms",
@@ -48,6 +116,8 @@ async def mirror_rpms(runtime: Runtime, version: str, assembly: str, local_plash
             s3_path = f'/enterprise/all/{stream_version}/latest/'
             await sync_repo_to_s3_mirror(local_plashet_path, s3_path, runtime.dry_run)
 
+        runtime.logger.info('Finished mirroring OCP %s to openshift mirrors', version)
+
     except ChildProcessError as e:
         error_msg = f'Failed syncing {local_plashet_path} repo to art-srv-enterprise S3: {e}',
         runtime.logger.error(error_msg)
@@ -56,11 +126,10 @@ async def mirror_rpms(runtime: Runtime, version: str, assembly: str, local_plash
         slack_client.bind_channel(f'openshift-{stream_version}')
         await slack_client.say(error_msg)
         raise
+
     except LockError as e:
         runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
         raise
 
     finally:
         await lock_manager.destroy()
-
-    runtime.logger.info('Finished mirroring OCP %s to openshift mirrors', version)

--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -1,0 +1,278 @@
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence, Optional, Tuple
+
+import yaml
+
+from pyartcd import exectools
+from pyartcd.constants import PLASHET_REMOTE_HOST
+from pyartcd.release import ocp_release_state
+
+working_dir = "plashet-working"
+
+logger = logging.getLogger('pyartcd')
+
+previous_packages = [
+    "conmon",
+    "cri-o",
+    "cri-tools",
+    "crun",
+    "haproxy",
+    "ignition",
+    "openshift",
+    "openvswitch",
+    "ovn",
+    "podman",
+    "python3-openvswitch",
+]
+
+
+def plashet_config_for_major_minor(major, minor):
+    return {
+        "rhel-9-server-ose-rpms-embargoed": {
+            "slug": "el9-embargoed",
+            "tag": f"rhaos-{major}.{minor}-rhel-9-candidate",
+            "product_version": f"OSE-{major}.{minor}-RHEL-9",
+            "include_embargoed": True,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-9-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+        "rhel-9-server-ose-rpms": {
+            "slug": "el9",
+            "tag": f"rhaos-{major}.{minor}-rhel-9-candidate",
+            "product_version": f"OSE-{major}.{minor}-RHEL-9",
+            "include_embargoed": False,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-9-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+        "rhel-9-server-ironic-rpms": {
+            "slug": "ironic-el9",
+            "tag": f"rhaos-{major}.{minor}-ironic-rhel-9-candidate",
+            "product_version": f"OSE-IRONIC-{major}.{minor}-RHEL-9",
+            "include_embargoed": False,
+            "embargoed_tags": [],  # unlikely to exist until we begin using -gating tag
+            "include_previous_packages": [],
+        },
+        "rhel-8-server-ose-rpms-embargoed": {
+            "slug": "el8-embargoed",
+            "tag": f"rhaos-{major}.{minor}-rhel-8-candidate",
+            "product_version": f"OSE-{major}.{minor}-RHEL-8",
+            "include_embargoed": True,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-8-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+        "rhel-8-server-ose-rpms": {
+            "slug": "el8",
+            "tag": f"rhaos-{major}.{minor}-rhel-8-candidate",
+            "product_version": f"OSE-{major}.{minor}-RHEL-8",
+            "include_embargoed": False,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-8-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+        "rhel-8-server-ironic-rpms": {
+            "slug": "ironic-el8",
+            "tag": f"rhaos-{major}.{minor}-ironic-rhel-8-candidate",
+            "product_version": f"OSE-IRONIC-{major}.{minor}-RHEL-8",
+            "include_embargoed": False,
+            "embargoed_tags": [],  # unlikely to exist until we begin using -gating tag
+            "include_previous_packages": [],
+        },
+        "rhel-server-ose-rpms-embargoed": {
+            "slug": "el7-embargoed",
+            "tag": f"rhaos-{major}.{minor}-rhel-7-candidate",
+            "product_version": f"RHEL-7-OSE-{major}.{minor}",
+            "include_embargoed": True,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-7-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+        "rhel-server-ose-rpms": {
+            "slug": "el7",
+            "tag": f"rhaos-{major}.{minor}-rhel-7-candidate",
+            "product_version": f"RHEL-7-OSE-{major}.{minor}",
+            "include_embargoed": False,
+            "embargoed_tags": [f"rhaos-{major}.{minor}-rhel-7-embargoed"],
+            "include_previous_packages": previous_packages,
+        },
+    }
+
+
+async def build_plashets(stream: str, release: str, assembly: str = 'stream', dry_run: bool = False):
+    """
+    Unless no RPMs have changed, create multiple yum repos (one for each arch) of RPMs
+    based on -candidate tags. Based on release state, those repos can be signed
+    (release state) or unsigned (pre-release state)
+
+    :param stream: e.g. 4.14
+    :param release: e.g. 202304181947.p?
+    :param assembly: e.g. assembly name, defaults to 'stream'
+    :param dry_run: do not actually run the command, just log it
+    """
+
+    major, minor = stream.split('.')  # e.g. ('4', '14') from '4.14'
+    revision = release.replace('.p?', '')  # e.g. '202304181947' from '202304181947.p?'
+
+    # Load group config
+    rc, stdout, stderr = await exectools.cmd_gather_async(
+        ['doozer', '--working-dir=doozer-working', '-q', f'--group=openshift-{stream}', 'config:read-group']
+    )
+    group_config = yaml.safe_load(stdout.strip())
+
+    # Check if assemblies are enabled for current group
+    if not group_config.get('assemblies', {}).get('enabled'):
+        assembly = 'stream'
+        logger.warning("Assembly name reset to 'stream' because assemblies are not enabled in ocp-build-data.")
+
+    # Get plashet repos
+    group_repos = group_config.get('repos', None)
+    group_plashet_config = plashet_config_for_major_minor(major, minor)
+    plashet_config = {repo: group_plashet_config[repo] for repo in group_plashet_config if repo in group_repos}
+    logger.info("Building plashet repos: %s", ", ".join(plashet_config.keys()))
+
+    # Check release state
+    signing_mode = 'signed' if ocp_release_state[stream]['release'] else 'unsigned'
+
+    # Create plashet repos on ocp-artifacts
+    # We can't safely run doozer config:plashet from-tags in parallel as this moment.
+    # Build plashet repos one by one.
+    plashets_built = {}  # hold the information of all built plashet repos
+    timestamp = datetime.strptime(revision, '%Y%m%d%H%M%S')
+    signing_advisory = group_config.get('signing_advisory', '0')
+    arches = ocp_release_state[stream]['release'] + ocp_release_state[stream]['pre-release']
+
+    for repo_type, config in plashet_config.items():
+        logger.info('Building plashet repo for %s', repo_type)
+        slug = config['slug']
+        name = f'{timestamp.year}-{timestamp.month:02}/{revision}'
+        base_dir = Path(working_dir, f'plashets/{major}.{minor}/{assembly}/{slug}')
+        local_path = await build_plashet_from_tags(
+            group=f'openshift-{stream}',
+            assembly=assembly,
+            base_dir=base_dir,
+            name=name,
+            arches=arches,
+            include_embargoed=config['include_embargoed'],
+            signing_mode=signing_mode,
+            signing_advisory=signing_advisory,
+            embargoed_tags=config['embargoed_tags'],
+            tag_pvs=((config["tag"], config['product_version']),),
+            include_previous_packages=config['include_previous_packages'],
+            dry_run=dry_run
+        )
+
+        logger.info('Plashet repo for %s created: %s', repo_type, local_path)
+        symlink_path = create_latest_symlink(
+            base_dir=base_dir, plashet_name=name)
+        logger.info('Symlink for %s created: %s', repo_type, symlink_path)
+
+        remote_base_dir = Path(f'/mnt/data/pub/RHOCP/plashets/{major}.{minor}/{assembly}/{slug}')
+        logger.info('Copying %s to remote host...', base_dir)
+        await copy_to_remote(base_dir, remote_base_dir, dry_run=dry_run)
+
+        plashets_built[repo_type] = {
+            'plashetDirName': revision,
+            'localPlashetPath': str(local_path),
+        }
+
+    logger.info('Plashets built: %s', plashets_built)
+
+    with open(f'{working_dir}/plashets_built.yaml', 'w') as outfile:
+        yaml.dump(plashets_built, outfile)
+        logger.info('Built plashets dumped to %s', os.path.abspath(outfile.name))
+
+
+async def build_plashet_from_tags(group: str, assembly: str, base_dir: os.PathLike, name: str, arches: Sequence[str],
+                                  include_embargoed: bool, signing_mode: str, signing_advisory: int,
+                                  tag_pvs: Sequence[Tuple[str, str]], embargoed_tags: Optional[Sequence[str]],
+                                  include_previous_packages: Optional[Sequence[str]] = None,
+                                  poll_for: int = 0, dry_run: bool = False):
+    """
+    Builds Plashet repo with "from-tags"
+    """
+
+    repo_path = Path(base_dir, name)
+    if repo_path.exists():
+        shutil.rmtree(repo_path)
+    cmd = [
+        "doozer",
+        "--working-dir", "doozer-working",
+        "--group", group,
+        "--assembly", assembly,
+        "config:plashet",
+        "--base-dir", str(base_dir),
+        "--name", name,
+        "--repo-subdir", "os"
+    ]
+    for arch in arches:
+        cmd.extend(["--arch", arch, signing_mode])
+    cmd.extend([
+        "from-tags",
+        "--signing-advisory-id", f"{signing_advisory or 54765}",
+        "--signing-advisory-mode", "clean",
+        "--inherit",
+    ])
+    if include_embargoed:
+        cmd.append("--include-embargoed")
+    if embargoed_tags:
+        for t in embargoed_tags:
+            cmd.extend(["--embargoed-brew-tag", t])
+    for tag, pv in tag_pvs:
+        cmd.extend(["--brew-tag", tag, pv])
+    for pkg in include_previous_packages:
+        cmd.extend(["--include-previous-for", pkg])
+    if poll_for:
+        cmd.extend(["--poll-for", str(poll_for)])
+
+    if dry_run:
+        repo_path.mkdir(parents=True)
+        logger.warning("[Dry run] Would have run %s", cmd)
+    else:
+        logger.info("Executing %s", cmd)
+        await exectools.cmd_assert_async(cmd, env=os.environ.copy())
+    return os.path.abspath(Path(base_dir, name))
+
+
+def create_latest_symlink(base_dir: os.PathLike, plashet_name: str):
+    symlink_path = Path(base_dir, "latest")
+    if symlink_path.is_symlink():
+        symlink_path.unlink()
+    symlink_path.symlink_to(plashet_name, target_is_directory=True)
+    return symlink_path
+
+
+async def copy_to_remote(local_base_dir: os.PathLike, remote_base_dir: os.PathLike, dry_run: bool = False):
+    """
+    Copies plashet out to remote host (ocp-artifacts)
+    """
+
+    # Make sure the remote base dir exist
+    local_base_dir = Path(local_base_dir)
+    remote_base_dir = Path(remote_base_dir)
+    cmd = [
+        "ssh",
+        PLASHET_REMOTE_HOST,
+        "--",
+        "mkdir",
+        "-p",
+        "--",
+        f"{remote_base_dir}",
+    ]
+    if dry_run:
+        logger.warning("[DRY RUN] Would have run %s", cmd)
+    else:
+        logger.info("Executing %s", ' '.join(cmd))
+        await exectools.cmd_assert_async(cmd, env=os.environ.copy())
+
+    # Copy local dir to remote
+    cmd = [
+        "rsync", "-av", "--links", "--progress", "-h", "--no-g", "--omit-dir-times", "--chmod=Dug=rwX,ugo+r",
+        "--perms", "--", f"{local_base_dir}/", f"{PLASHET_REMOTE_HOST}:{remote_base_dir}"
+    ]
+
+    if dry_run:
+        logger.warning("[DRY RUN] Would have run %s", cmd)
+    else:
+        logger.info("Executing %s", ' '.join(cmd))
+        await exectools.cmd_assert_async(cmd, env=os.environ.copy())

--- a/pyartcd/pyartcd/release.py
+++ b/pyartcd/pyartcd/release.py
@@ -1,0 +1,79 @@
+"""
+Why is ocp_release_state needed?
+To decide whether to build and use signed RPMs, and to decide if a strict
+bug validation flow is necessary.
+Before auto-signing, images were either built signed or unsigned.
+Unsigned images were the norm and then, right before GA, we would rebuild
+puddles and build as signed. In the new model, we always want to build
+signed **if we plan on releasing the builds via an advisory**.
+There are a category of builds that we DON'T plan on releasing through
+an advisory. For a brand new release stream (or new arch) in 4.x, we want
+to build nightlies and make them available as pre-release builds so that
+even the general public can start experimenting with the new features of the release.
+These pre-release images contain RPMs which have traditionally been unsigned.
+We need them to continue to be unsigned!
+Any code we sign using the auto-signing facility should be passed through
+the errata process / rpmdiff.
+Hence we need a very explicit source of truth on where our images are
+destined. If it will ship via errata (state=release), we want to build signed. For
+early access without an errata (state=pre-release).
+For extra complexity, different architectures in a release can be in
+different release states. For example, s390x might still be pre-release
+even after x86_64 is shipping for a given 4.x. While we could theoretically build the
+x86_64 image with signed RPMs, and s390x images with unsigned RPMS, OSBS
+prohibits this since it considers it an error.
+TODO: ask osbs to make this a configurable option?
+Sooooo... when all arches are pre-release, we need to build unsigned. When any
+arch is in release mode, we need to build all images with signed RPMs.
+Why is release map information not in doozer metadata. It could be.
+1) I think it would need some refactoring that won't be practical until
+   the auto-signing work is validated.
+2) We normally initialize a new doozer group by copying an old one. This
+   release state could easily be copied unintentionally.
+3) pre-release data is presently stored in poll-payload. This just tries
+   to make it available for other jobs.
+Alternatively, maybe this becomes the source of truth and confusing aspects like
+'archOverrides' goes away in doozer config.
+"""
+ocp_release_state = {
+    '4.14': {
+        'release': [],
+        'pre-release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+    },
+    '4.13': {
+        'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+        'pre-release': [],
+    },
+    '4.12': {
+        'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+        'pre-release': [],
+    },
+    '4.11': {
+        'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+        'pre-release': [],
+    },
+    '4.10': {
+        'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+        'pre-release': [],
+    },
+    '4.9': {
+        'release': ['x86_64', 's390x', 'ppc64le', 'aarch64'],
+        'pre-release': [],
+    },
+    '4.8': {
+        'release': ['x86_64', 's390x', 'ppc64le'],
+        'pre-release': ['aarch64'],
+    },
+    '4.7': {
+        'release': ['x86_64', 's390x', 'ppc64le'],
+        'pre-release': ['aarch64'],
+    },
+    '4.6': {
+        'release': ['x86_64', 's390x', 'ppc64le'],
+        'pre-release': ['aarch64'],
+    },
+    '3.11': {
+        'release': ['x86_64'],
+        'pre-release': ['ppc64le', 's390x', 'aarch64'],
+    },
+}


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-3672

This PR migrates the whole `build compose` stage to Python. Once merged, we can use the same approach to port `custom` job to Python as well, and get rid of `hacks/plashet/build-plashet.py` that has been ported to pyartcd. Then, we can also remove `buildlib.build_plashets()`

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/59/console

Produced 4.7 plashets: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/4.7/stream/