### PR TITLE
Issue cache invalidation after syncing rhacs

### DIFF
--- a/scheduled-jobs/build/sync-rhacs/Jenkinsfile
+++ b/scheduled-jobs/build/sync-rhacs/Jenkinsfile
@@ -33,6 +33,7 @@ node() {
                     set -e
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/assets/ s3://art-srv-enterprise/pub/rhacs/assets/
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/charts/ s3://art-srv-enterprise/pub/rhacs/charts/
+                    aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "/pub/rhacs/*"
                 """
             )
         }


### PR DESCRIPTION
There were inconsistent results from different clients. Invalidation is necessary.