### PR TITLE
ocp4: remove --comment-on-pr from doozer images:build

### DIFF
--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -332,7 +332,6 @@ def stageBuildImages() {
             ${includeExclude "images", buildPlan.imagesIncluded, buildPlan.imagesExcluded}
             images:build
             --repo-type ${signing_mode}
-            --comment-on-pr
             """
 
         def includedCount = commonlib.parseList(buildPlan.imagesIncluded).size()


### PR DESCRIPTION
This feature needs some tweaking as it's been spamming PRs with multiple messages, see for example https://github.com/openshift/network-tools/pull/75