### PR TITLE
Do not empty out ocp4 description at start

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -119,7 +119,10 @@ node {
 
     commonlib.checkMock()
 
-    currentBuild.description = ""
+    if (currentBuild.description == null) {
+        currentBuild.description = ""
+    }
+
     try {
 
         sshagent(["openshift-bot"]) {

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -130,7 +130,7 @@ def displayTagFor(commaList, kind, isExcluded=false){
  */
 def planBuilds() {
     if (buildPlan.forceBuild) {
-        currentBuild.description = "Force building (whether source changed or not).<br/>"
+        currentBuild.description += "Force building (whether source changed or not).<br/>"
         currentBuild.description +=
             (!buildPlan.buildRpms) ? "RPMs: not building.<br/>" :
             (buildPlan.rpmsIncluded) ? "RPMs: building ${buildPlan.rpmsIncluded}.<br/>" :


### PR DESCRIPTION
ocp4-scan is trying to initially set the build description by linking the upstream build  that caused it. Jenkinsfile is overwriting it, so we lose links between builds.