### PR TITLE
Rename pyartcd.jenkins.jenkins into pyartcd.jenkins.jenkins_client

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -23,12 +23,12 @@ class Jobs(Enum):
     OLM_BUNDLE = 'aos-cd-builds/build%2Folm_bundle'
 
 
-jenkins: Optional[Jenkins] = None
+jenkins_client: Optional[Jenkins] = None
 
 
 def init_jenkins():
-    global jenkins
-    if jenkins:
+    global jenkins_client
+    if jenkins_client:
         return
     logger.info('Initializing Jenkins client..')
     requester = CrumbRequester(
@@ -37,14 +37,14 @@ def init_jenkins():
         baseurl=constants.JENKINS_SERVER_URL
     )
 
-    jenkins = Jenkins(
+    jenkins_client = Jenkins(
         constants.JENKINS_SERVER_URL,
         username=os.environ['JENKINS_SERVICE_ACCOUNT'],
         password=os.environ['JENKINS_SERVICE_ACCOUNT_TOKEN'],
         requester=requester,
         lazy=True
     )
-    logger.info('Connected to Jenkins %s', jenkins.version)
+    logger.info('Connected to Jenkins %s', jenkins_client.version)
 
 
 def block_until_building(queue_item: QueueItem, delay: int = 5) -> str:
@@ -83,7 +83,7 @@ def start_build(job_name: str, params: dict, blocking: bool = False,
 
     init_jenkins()
     logger.info('Starting new build for job: %s', job_name)
-    job = jenkins.get_job(job_name)
+    job = jenkins_client.get_job(job_name)
     queue_item = job.invoke(build_params=params)
     build_url = block_until_building(queue_item, watch_building_delay)
     logger.info('Started new build at %s', build_url)

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -48,7 +48,7 @@ class Ocp4ScanPipeline:
 
             # Trigger ocp4
             self.logger.info('Triggering a %s ocp4 build', self.version)
-            jenkins.start_ocp4(build_version=self.version, blocking=False)
+            jenkins_client.start_ocp4(build_version=self.version, blocking=False)
 
         elif self.rhcos_inconsistent:
             self.logger.info('Detected inconsistent RHCOS RPMs:\n%s', self.inconsistent_rhcos_rpms)
@@ -60,7 +60,7 @@ class Ocp4ScanPipeline:
             # Inconsistency probably means partial failure and we would like to retry.
             #  but don't kick off more if already in progress.
             self.logger.info('Triggering a %s RHCOS build for consistency', self.version)
-            jenkins.start_rhcos(build_version=self.version, new_build=True, blocking=False)
+            jenkins_client.start_rhcos(build_version=self.version, new_build=True, blocking=False)
 
         elif self.rhcos_changed:
             self.logger.info('Detected at least one updated RHCOS')
@@ -70,7 +70,7 @@ class Ocp4ScanPipeline:
                 return
 
             self.logger.info('Triggering a %s build-sync', self.version)
-            jenkins.start_build_sync(build_version=self.version, blocking=False)
+            jenkins_client.start_build_sync(build_version=self.version, blocking=False)
 
     async def _get_changes(self):
         """

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -445,7 +445,7 @@ class PromotePipeline:
 
         if not util.is_rpm_pinned(releases_config, self.assembly, 'microshift'):
             self._logger.info("Microshift is not pinned in the assembly config. Starting build...")
-            jenkins.start_build_microshift(f'{major}.{minor}', self.assembly, self.runtime.dry_run)
+            jenkins_client.start_build_microshift(f'{major}.{minor}', self.assembly, self.runtime.dry_run)
         else:
             self._logger.info("Microshift is pinned in the assembly config. Skipping build. If a rebuild is required, please manually run build-microshift job.")
 

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -284,7 +284,7 @@ async def sync_images(version: str, assembly: str, operator_nvrs: list,
     if assembly == 'test':
         logger.warning('Skipping build-sync job for test assembly')
     else:
-        jenkins.start_build_sync(
+        jenkins_client.start_build_sync(
             build_version=version,
             assembly=assembly,
             doozer_data_path=doozer_data_path,
@@ -292,7 +292,7 @@ async def sync_images(version: str, assembly: str, operator_nvrs: list,
         )
 
     if operator_nvrs:
-        jenkins.start_olm_bundle(
+        jenkins_client.start_olm_bundle(
             build_version=version,
             assembly=assembly,
             operator_nvrs=operator_nvrs,


### PR DESCRIPTION
This is to avoid confusion when importing the module, as in https://github.com/openshift-eng/aos-cd-jobs/pull/3684