### PR TITLE
Provide ocp4:sweep pyartcd CLI with JIRA_TOKEN env var

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -262,7 +262,9 @@ node {
                 ]
 
                 try {
-                    sh(script: cmd.join(' '), returnStdout: true)
+                    withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                        sh(script: cmd.join(' '), returnStdout: true)
+                    }
                 } catch (err) {
                     currentBuild.result = 'UNSTABLE'
                     if (dry_run) {


### PR DESCRIPTION
Fix 
```
ValueError: elliott requires login credentials for https://issues.redhat.com/. Set a JIRA_TOKEN env var
```