### PR TITLE
[ART-6099] Add job to ingest weekly kernel

### DIFF
--- a/jobs/build/tag-rpms/Jenkinsfile
+++ b/jobs/build/tag-rpms/Jenkinsfile
@@ -1,0 +1,86 @@
+node {
+    wrap([$class: "BuildUser"]) {
+        checkout scm
+        def buildlib = load("pipeline-scripts/buildlib.groovy")
+        def commonlib = buildlib.commonlib
+
+        commonlib.describeJob("tag-rpms", """
+            <h2>This job will check rpms in configured Brew tags then tag them into target Brew tags.</h2>
+            <p>This is mainly to support weekly kernel release via OCP</p>
+            <p>If you untag a build from a target Brew tag, it will not be tagged by this job anymore.</p>
+            <b>Timing</b>: Usually triggered by timer
+        """)
+
+        properties(
+            [
+                disableResume(),
+                buildDiscarder(
+                    logRotator(
+                        artifactDaysToKeepStr: "",
+                        artifactNumToKeepStr: "",
+                        daysToKeepStr: "",
+                        numToKeepStr: "")),
+                [
+                    $class: "ParametersDefinitionProperty",
+                    parameterDefinitions: [
+                        commonlib.ocpVersionParam('VERSION'),
+                        booleanParam(
+                            name: "DRY_RUN",
+                            description: "Take no action, just echo what the job would have done.",
+                            defaultValue: false
+                        ),
+                        string(
+                            name: 'DOOZER_DATA_PATH',
+                            description: 'ocp-build-data fork to use (e.g. test customizations on your own fork)',
+                            defaultValue: "https://github.com/openshift-eng/ocp-build-data",
+                            trim: true,
+                        ),
+                        commonlib.mockParam(),
+                    ]
+                ],
+            ]
+        )   // Please update README.md if modifying parameter names or semantics
+
+        commonlib.checkMock()
+        stage("initialize") {
+            currentBuild.displayName += " $params.VERSION"
+        }
+        try {
+            stage("tag-rpms") {
+                sh "mkdir -p ./artcd_working"
+                def cmd = [
+                    "artcd",
+                    "-v",
+                    "--working-dir=./artcd_working",
+                    "--config", "./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
+                    "tag-rpms",
+                    "--group", "openshift-${params.VERSION}",
+                ]
+                if (params.DOOZER_DATA_PATH) {
+                    cmd << "--data-path=${params.DOOZER_DATA_PATH}"
+                }
+                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                    echo "Will run ${cmd}"
+                    commonlib.shell(script: cmd.join(' '))
+                }
+            }
+        } catch (err) {
+            currentBuild.result = "FAILURE"
+            throw err
+        } finally {
+            commonlib.safeArchiveArtifacts([
+                "artcd_working/email/**",
+                "artcd_working/**/*.json",
+                "artcd_working/**/*.log",
+                "artcd_working/**/*.yaml",
+                "artcd_working/**/*.yml",
+            ])
+            buildlib.cleanWorkspace()
+        }
+    }
+}

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, custom, scan_for_kernel_bugs
+    olm_bundle, ocp4, custom, scan_for_kernel_bugs, tag_rpms
 )
 
 

--- a/pyartcd/pyartcd/cli.py
+++ b/pyartcd/pyartcd/cli.py
@@ -15,8 +15,6 @@ def click_coroutine(f):
     """ A wrapper to allow to use asyncio with click.
     https://github.com/pallets/click/issues/85
     """
-    f = asyncio.coroutine(f)
-
     def wrapper(*args, **kwargs):
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(f(*args, **kwargs))

--- a/pyartcd/pyartcd/pipelines/tag_rpms.py
+++ b/pyartcd/pyartcd/pipelines/tag_rpms.py
@@ -1,0 +1,94 @@
+
+import json
+import os
+import traceback
+from typing import Optional
+
+import click
+
+from pyartcd import constants, exectools
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+
+
+class TagRPMsPipeline:
+    def __init__(self, runtime: Runtime, data_path: Optional[str], group: str) -> None:
+        self._runtime = runtime
+        self.data_path = data_path or runtime.config.get("build_config", {}).get("ocp_build_data_url")
+        self.group = group
+
+        self._working_dir = self._runtime.working_dir
+        self._doozer_working_dir = self._working_dir / "doozer-working"
+        self._doozer_env_vars = os.environ.copy()
+        self._doozer_env_vars["DOOZER_WORKING_DIR"] = str(self._doozer_working_dir)
+        if self.data_path:
+            self._doozer_env_vars["DOOZER_DATA_PATH"] = self.data_path
+
+    async def run(self):
+        logger = self._runtime.logger
+        slack_client = self._runtime.new_slack_client()
+        slack_client.bind_channel(self.group)
+        try:
+            logger.info("Running doozer config:tag-rpms for %s...", self.group)
+            report = await self.tag_rpms()
+            untagged = False
+            tagged = False
+            message = ""
+            if report["untagged"]:
+                for tag, nvrs in report["untagged"].items():
+                    if not nvrs:
+                        continue
+                    untagged = True
+                    message += f"{len(nvrs)} builds have been untagged from Brew tag {tag}:\n"
+                    for nvr in nvrs:
+                        message += f"\t{nvr}\n"
+                if untagged:
+                    message += "Builds were untagged because they were tagged into the stop-ship tags.\n\n"
+            if report["tagged"]:
+                for tag, nvrs in report["tagged"].items():
+                    if not nvrs:
+                        continue
+                    tagged = True
+                    message += f"{len(nvrs)} builds have been tagged into Brew tag {tag}:\n"
+                    for nvr in nvrs:
+                        message += f"\t{nvr}\n"
+                    message += f"To revert, run `brew untag {tag} {' '.join(nvrs)}`.\n"
+                if tagged:
+                    message += "If you untag a build manually, it will not be re-tagged by this job again.\n\n"
+            if untagged or tagged:  # Don't spam release-artists if nothing changed
+                await slack_client.say(f":white_check_mark: Hi @release-artists ,\n{message}")
+        except Exception as err:
+            error_message = f"Error running tag-rpms: {err}\n {traceback.format_exc()}"
+            logger.error(error_message)
+            await slack_client.say(f":warning: {error_message}")
+            raise
+
+    async def tag_rpms(self):
+        """ run doozer config:tag-rpms
+        :return: a dict containing which packages have been tagged and untagged
+        """
+        cmd = [
+            "doozer",
+            "--group", self.group,
+            "--assembly", "stream",
+            "config:tag-rpms",
+            "--json",
+        ]
+        if self._runtime.dry_run:
+            cmd.append("--dry-run")
+        _, out, _ = await exectools.cmd_gather_async(cmd, stderr=None, env=self._doozer_env_vars)
+        # example out:
+        # {"untagged": {"test-target-tag": ["bar-1.0.0-1"]}, "tagged": {"test-target-tag": ["bar-1.0.2-1", "foo-1.0.1-1"]}}
+        return json.loads(out)
+
+
+@cli.command("tag-rpms", short_help="Tag and untag rpms for rpm delivery")
+@click.option("--data-path", metavar='BUILD_DATA', default=None,
+              help=f"Git repo or directory containing groups metadata e.g. {constants.OCP_BUILD_DATA_URL}")
+@click.option("-g", "--group", metavar='NAME', required=True,
+              help="The group of components on which to operate. e.g. openshift-4.12")
+@pass_runtime
+@click_coroutine
+async def tag_rpms_cli(runtime: Runtime, data_path: Optional[str], group: str):
+    pipeline = TagRPMsPipeline(runtime=runtime, data_path=data_path, group=group)
+    await pipeline.run()

--- a/scheduled-jobs/build/tag-rpms/Jenkinsfile
+++ b/scheduled-jobs/build/tag-rpms/Jenkinsfile
@@ -1,0 +1,46 @@
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
+
+description = ""
+failed = false
+
+def runFor(version) {
+    try {
+        timeout(activity: true, time: 20, unit: 'MINUTES') {
+            b = build(
+                job: '../aos-cd-builds/build%2Ftag-rpms',
+                parameters: [
+                    string(name: 'VERSION', value: version),
+                ],
+                propagate: false,
+            )
+        }
+        description += "${version} - ${b.result}\n"
+        failed |= (b.result != "SUCCESS")
+    } catch (te) {
+        description += "${version} - ERROR\n"
+        failed = true
+    }
+}
+
+@NonCPS
+def sortedVersions() {
+  return commonlib.ocpVersions.sort(false)
+}
+
+node() {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+
+    for ( String version : sortedVersions() ) {
+        runFor(version)
+    }
+    buildlib.cleanWorkspace()
+}
+
+currentBuild.description = description.trim()
+currentBuild.result = failed ? "FAILURE" : "SUCCESS"

--- a/scheduled-jobs/build/tag-rpms/Jenkinsfile
+++ b/scheduled-jobs/build/tag-rpms/Jenkinsfile
@@ -28,7 +28,7 @@ def runFor(version) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocpVersions.sort(false)
+  return commonlib.ocp4Versions.sort(false)
 }
 
 node() {


### PR DESCRIPTION
A new scheduled job `tag-rpms` is added to run `doozer config:tag-rpms` command to ingest weekly candidate kernel as defined in `rpm_deliveries` field of group config.

A slack message will be sent if any rpms are tagged or untagged by this job.