### PR TITLE
ART-6806 Remove attach-cve-flaw from promote

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -78,11 +78,6 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
-                        name: 'SKIP_ATTACH_CVE_FLAWS',
-                        description: 'Do not attach CVE flaws bugs',
-                        defaultValue: false,
-                    ),
-                    booleanParam(
                         name: 'SKIP_SIGNING',
                         description: 'Do not sign the release.',
                         defaultValue: false,
@@ -152,9 +147,6 @@ node {
         }
         if (params.SKIP_IMAGE_LIST) {
             cmd << "--skip-image-list"
-        }
-        if (params.SKIP_ATTACH_CVE_FLAWS) {
-            cmd << "--skip-attach-cve-flaws"
         }
         if (params.SKIP_BUILD_MICROSHIFT) {
             cmd << "--skip-build-microshift"

--- a/jobs/build/promote-assembly/README.md
+++ b/jobs/build/promote-assembly/README.md
@@ -175,7 +175,6 @@ releases:
 Promotion Permit codes:
 - *BLOCKER_BUGS* Permit failing Blocker-Bugs check for a release.
 - *ATTACHED_BUGS* Permit failing Verify-attached-bugs validation for release advisories.
-- *CVE_FLAWS* Permit failing Attach-CVE-flaws (bugs) to release advisories.
 - *NO_ERRATA* Permit standard assembly to not have an Image advisory.
 - *INVALID_ERRATA_STATUS* Permit standard assembly release advisories to not have LiveID or be in undesired Errata status.
 

--- a/pyartcd/tests/pipelines/test_promote.py
+++ b/pyartcd/tests/pipelines/test_promote.py
@@ -199,7 +199,6 @@ class TestPromotePipeline(TestCase):
         pipeline = PromotePipeline(runtime, group="openshift-4.10", assembly="4.10.99", release_offset=None)
         pipeline._slack_client = AsyncMock()
         pipeline.check_blocker_bugs = AsyncMock()
-        pipeline.attach_cve_flaws = AsyncMock()
         pipeline.change_advisory_state = AsyncMock()
         pipeline.get_advisory_info = AsyncMock(return_value={
             "id": 2,
@@ -218,7 +217,6 @@ class TestPromotePipeline(TestCase):
         load_releases_config.assert_awaited_once_with(Path("/path/to/working/doozer-working/ocp-build-data"))
         pipeline.check_blocker_bugs.assert_awaited_once_with()
         for advisory in [1, 2, 3, 4]:
-            pipeline.attach_cve_flaws.assert_any_await(advisory)
             pipeline.change_advisory_state.assert_any_await(advisory, "QE")
         pipeline.get_advisory_info.assert_awaited_once_with(2)
         pipeline.verify_attached_bugs.assert_awaited_once_with([1, 2, 3, 4], no_verify_blocking_bugs=False)


### PR DESCRIPTION
https://issues.redhat.com/browse/ART-6806
Since now we run attach-cve-flaws in prepare-release, we don't need to run it again at promote time.
