### PR TITLE
Fix poll payload with EC

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -41,7 +41,7 @@ node {
                     string(
                         name: 'ARCHES',
                         description: 'all, or a space delimited list of arches: "x86_64 s390x ..."',
-                        defaultValue: "all",
+                        defaultValue: "x86_64 s390x",
                         trim: true,
                     ),
                     booleanParam(

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -32,9 +32,9 @@ import groovy.json.JsonOutput
 ]
 
 def setDevPreviewLatest(String releaseStream, Map latestRelease, Map previousRelease) {
-    def buildVersion = commonlib.extractMajorMinorVersion(releaseStream)
-    def arch = commonlib.extractArchFromReleaseName(latestRelease.name)
-    release.stageSetClientLatest(latestRelease.name, arch, "ocp-dev-preview")
+    def buildVersion = commonlib.extractMajorMinorVersion(latestRelease.name)
+    def arch = commonlib.extractArchFromReleaseName(releaseStream)
+    release.stageSetClientLatest("candidate-${buildVersion}", arch, "ocp-dev-preview")
 }
 
 def publishRPMsEl9(String releaseStream, Map latestRelease, Map previousRelease) {


### PR DESCRIPTION
ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1685458972839399
in this function context
latestRelease.name for ec is 4.14.0-ec.1
releaseStream for ec is 4-dev-preview-s390x
and set client latest job only accept channel parameter, for ec it should only have candidate channel 
the error in the job https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/scheduled-builds/job/poll-payload/131591/console is it can't extract version from value 4-dev-preview-s390x