### PR TITLE
[ART-6964] Add a job to clone kernel bugs to OCP

### DIFF
--- a/jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -1,0 +1,105 @@
+import java.text.SimpleDateFormat
+
+node {
+    wrap([$class: "BuildUser"]) {
+        checkout scm
+        def buildlib = load("pipeline-scripts/buildlib.groovy")
+        def commonlib = buildlib.commonlib
+
+        commonlib.describeJob("scan-for-kernel-bugs", """
+            <h2>This job scans for kernel bugs, clones them into OCP Jira, and moves their statuses.</h2>
+            <b>Timing</b>: Usually triggered by timer
+        """)
+
+        properties(
+            [
+                disableResume(),
+                buildDiscarder(
+                    logRotator(
+                        artifactDaysToKeepStr: "",
+                        artifactNumToKeepStr: "",
+                        daysToKeepStr: "",
+                        numToKeepStr: "")),
+                [
+                    $class: "ParametersDefinitionProperty",
+                    parameterDefinitions: [
+                        commonlib.ocpVersionParam('VERSION'),
+                        booleanParam(
+                            name: "DRY_RUN",
+                            description: "Take no action, just echo what the job would have done.",
+                            defaultValue: false
+                        ),
+                        booleanParam(
+                            name: "RECONCILE",
+                            description: "Update summary, description, etc for already cloned Jira bugs",
+                            defaultValue: false
+                        ),
+                        string(
+                            name: 'TRACKERS',
+                            description: '(Optional) List of KMAINT trackers to scan',
+                            defaultValue: "",
+                            trim: true,
+                        ),
+                        string(
+                            name: 'DOOZER_DATA_PATH',
+                            description: 'ocp-build-data fork to use (e.g. test customizations on your own fork)',
+                            defaultValue: "https://github.com/openshift-eng/ocp-build-data",
+                            trim: true,
+                        ),
+                        commonlib.mockParam(),
+                    ]
+                ],
+            ]
+        )   // Please update README.md if modifying parameter names or semantics
+
+        commonlib.checkMock()
+        stage("initialize") {
+            currentBuild.displayName += " $params.VERSION"
+        }
+        try {
+            stage("scan-for-kernel-bugs") {
+                sh "mkdir -p ./artcd_working"
+                def cmd = [
+                    "artcd",
+                    "-v",
+                    "--working-dir=./artcd_working",
+                    "--config", "./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
+                    "scan-for-kernel-bugs",
+                    "--group", "openshift-${params.VERSION}",
+                ]
+                if (params.DOOZER_DATA_PATH) {
+                    cmd << "--data-path=${params.DOOZER_DATA_PATH}"
+                }
+                if (params.RECONCILE) {
+                    cmd << "--reconcile"
+                }
+                if (params.TRACKERS) {
+                    for (tracker in commonlib.parseList(params.TRACKERS)) {
+                        cmd << "--tracker=${tracker.trim()}"
+                    }
+                }
+                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                    echo "Will run ${cmd}"
+                    commonlib.shell(script: cmd.join(' '))
+                }
+            }
+        } catch (err) {
+            currentBuild.result = "FAILURE"
+            throw err
+        } finally {
+            commonlib.safeArchiveArtifacts([
+                "artcd_working/email/**",
+                "artcd_working/**/*.json",
+                "artcd_working/**/*.log",
+                "artcd_working/**/*.yaml",
+                "artcd_working/**/*.yml",
+            ])
+            buildlib.cleanWorkspace()
+        }
+    }
+}

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, custom
+    olm_bundle, ocp4, custom, scan_for_kernel_bugs
 )
 
 

--- a/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
+++ b/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
@@ -1,0 +1,104 @@
+
+import os
+import traceback
+from typing import Optional, Tuple
+
+import click
+
+from pyartcd import constants, exectools
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+
+
+class ScanForKernelBugsPipeline:
+    def __init__(self, runtime: Runtime, data_path: Optional[str], group: str,
+                 reconcile: bool, trackers: Tuple[str, ...]) -> None:
+        self._runtime = runtime
+        self.data_path = data_path or runtime.config.get("build_config", {}).get("ocp_build_data_url")
+        self.group = group
+        self.reconcile = reconcile
+        self.trackers = list(trackers)
+        self._logger = runtime.logger
+
+        self._working_dir = self._runtime.working_dir
+        self._elliott_working_dir = self._working_dir / "elliott-working"
+        self._elliott_env_vars = os.environ.copy()
+        self._elliott_env_vars["ELLIOTT_WORKING_DIR"] = str(self._elliott_working_dir)
+        if self.data_path:
+            self._elliott_env_vars["ELLIOTT_DATA_PATH"] = self.data_path
+
+    async def run(self):
+        logger = self._logger
+        slack_client = self._runtime.new_slack_client()
+        slack_client.bind_channel(self.group)
+        try:
+            logger.info("Scanning KMAINT trackers for kernel bugs...")
+            await self._clone_kernel_bugs()
+            logger.info("Moving cloned Jira issues...")
+            await self._move_kernel_bugs()
+            logger.info("Done")
+        except Exception as err:
+            error_message = f"Error scanning for kernel bugs: {err}\n {traceback.format_exc()}"
+            logger.error(error_message)
+            await slack_client.say(f":warning: {error_message}")
+            raise
+
+    async def _clone_kernel_bugs(self):
+        """ Run `elliott find-bugs:kernel --clone`
+        :return: a dict containing which packages have been tagged and untagged
+        """
+        cmd = [
+            "elliott",
+            "--group", self.group,
+            "--assembly", "stream",
+            "find-bugs:kernel",
+            "--clone",
+            "--comment",
+        ]
+        if self.reconcile:
+            cmd.append("--reconcile")
+        if self.trackers:
+            cmd.extend([f"--tracker={tracker}" for tracker in self.trackers])
+        if self._runtime.dry_run:
+            cmd.append("--dry-run")
+        await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
+
+    async def _move_kernel_bugs(self):
+        """ Run `elliott find-bugs:kernel-clones --move`
+        :return: a dict containing which packages have been tagged and untagged
+        """
+        cmd = [
+            "elliott",
+            "--group", self.group,
+            "--assembly", "stream",
+            "find-bugs:kernel-clones",
+            "--move",
+            "--comment",
+        ]
+        if self.trackers:
+            cmd.extend([f"--tracker={tracker}" for tracker in self.trackers])
+        if self._runtime.dry_run:
+            cmd.append("--dry-run")
+        await exectools.cmd_assert_async(cmd, env=self._elliott_env_vars)
+
+
+@cli.command("scan-for-kernel-bugs", short_help="Scan for kernel bugs")
+@click.option("--data-path", metavar='BUILD_DATA', default=None,
+              help=f"Git repo or directory containing groups metadata e.g. {constants.OCP_BUILD_DATA_URL}")
+@click.option("-g", "--group", metavar='NAME', required=True,
+              help="The group of components on which to operate. e.g. openshift-4.12")
+@click.option("--reconcile",
+              is_flag=True,
+              help="Update summary, description, etc for already cloned Jira bugs")
+@click.option("--tracker", "trackers", metavar='JIRA_KEY', multiple=True,
+              help="Find kernel bugs by the specified KMAINT tracker JIRA_KEY")
+@pass_runtime
+@click_coroutine
+async def scan_for_kernel_bugs_cli(runtime: Runtime, data_path: Optional[str], group: str,
+                                   reconcile: bool, trackers: Tuple[str, ...]):
+    """ This job scans KMAINT Jira tracker for kernel bugs in Bugzilla, clones them into OCP Jira,
+    and move their statuses.
+    """
+    pipeline = ScanForKernelBugsPipeline(runtime=runtime, data_path=data_path, group=group,
+                                         reconcile=reconcile, trackers=trackers)
+    await pipeline.run()

--- a/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -1,0 +1,46 @@
+properties([
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+])
+
+description = ""
+failed = false
+
+def runFor(version) {
+    try {
+        timeout(activity: true, time: 20, unit: 'MINUTES') {
+            b = build(
+                job: '../aos-cd-builds/build%scan-for-kernel-bugs',
+                parameters: [
+                    string(name: 'VERSION', value: version),
+                ],
+                propagate: false,
+            )
+        }
+        description += "${version} - ${b.result}\n"
+        failed |= (b.result != "SUCCESS")
+    } catch (te) {
+        description += "${version} - ERROR\n"
+        failed = true
+    }
+}
+
+@NonCPS
+def sortedVersions() {
+  return commonlib.ocpVersions.sort(false)
+}
+
+node() {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+
+    for ( String version : sortedVersions() ) {
+        runFor(version)
+    }
+    buildlib.cleanWorkspace()
+}
+
+currentBuild.description = description.trim()
+currentBuild.result = failed ? "FAILURE" : "SUCCESS"


### PR DESCRIPTION
A job `scan-for-kernel-bugs` is added to periodically scan for kernel bugs, clone them into OCP, and move their statuses to MODIFIED when corresponding builds are tagged into candidate tags (rhaos-x.y-rhel-z-candidate) for OCP pipeline.

This job achieve this in 2 steps:

Step 1: Runs `elliott find-bugs:kernel --clone` to scan KMAINT trackers for kernel bugs, clone them into OCP (skip already cloned bugs), and make comments on those KMAINT trackers if builds are tagged.

Step 2: Runs `elliott find-bugs:kernel-clones --move` to move cloned kernel bugs to MODIFIED if corresponding builds are tagged into OCP candidate Brew tag (rhaos-x.y-rhel-z-candidate). Those MODIFIED bugs can be swept by ART's normal bug sweep and attached to Errata afterwards.

Requires https://github.com/openshift-eng/elliott/pull/555.