### PR TITLE
Temporarily re-enable old OCP versions for testing

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -13,7 +13,9 @@ ocp4Versions = [
     "4.11",
     "4.10",
     "4.9",
+    "4.8",
     "4.7",
+    "4.6",
 ]
 
 ocpVersions = ocp4Versions + ocp3Versions


### PR DESCRIPTION
Just a drill to exercise building old (no longer supported) OCP versions with current infrastructure.