### PR TITLE
[3.11] Read release state from group config instead of commonlib

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -175,10 +175,11 @@ def buildBuildingPlashet(version, release, el_major, include_embargoed, auto_sig
      * unsigned RPMs for one CPU arch and signed images for arch. Thus,
      * if one of our arches is in 'release' mode, we must build all
      * arches with signed.
-     * commonlib.ocpReleaseState declares which arches are in release / pre-release mode.
-     * Read the comment on that map for more information
      */
-    def archReleaseStates = commonlib.ocpReleaseState[major_minor]
+
+    def out = buildlib.doozer("--group=openshift-${params.BUILD_VERSION} config:read-group --yaml release_state",
+                              [capture: true]).trim()
+    def archReleaseStates = readYaml(text: out)
     def plashet_arch_args = ""
 
     for (String release_arch : archReleaseStates['release']) {


### PR DESCRIPTION
Testing out the new `release_state` in group.yml for OCP 3.11

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp3/27/console

Ref. https://issues.redhat.com/browse/ART-6729