### PR TITLE
fix sync mirror args

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -724,7 +724,7 @@ def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, 
     }
 }
 
-def syncDirToS3Mirror(local_dir, s3_path, include_only='', timeout_minutes=60, delete_old=true) {
+def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', timeout_minutes=60) {
     try {
         checkS3Path(s3_path)
         extra_args = ""


### PR DESCRIPTION
In our promote job we called with `delete_old=false` https://github.com/openshift-eng/aos-cd-jobs/blob/master/jobs/build/promote-assembly/Jenkinsfile#L201 but groovy treated it as position args and set include_only=false while delete_old=true as default. So --delete parameter is added.
this temporary fix is to set the variable in the correct order
It won't be an issue after migrating this function to python