### PR TITLE
[ART-7040] move sync rhcos step to python

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -188,21 +188,6 @@ node {
 
     stage("sync RHCOS") {
 
-        /* Sync potential pre-release source on which RHCOS depends. See ART-6419 for details. */
-        if ( major > 4 || (major == 4 && minor >= 13) ) {
-            if (release_info.type == 'candidate' || release_info.type == 'standard') {
-                def src_output_dir = "${WORKSPACE}/rhcos_src_staging"
-                sh "rm -rf ${src_output_dir}"
-                release_info.content.each { arch, info ->
-                    if (arch != "multi") {
-                        def rhcos_build = info.rhcos_version
-                        buildlib.doozer("--group openshift-${major}.${minor} --assembly ${params.ASSEMBLY} config:rhcos-srpms --version ${rhcos_build} --arch ${arch} -o ${src_output_dir}")
-                    }
-                }
-                commonlib.syncDirToS3Mirror("${src_output_dir}/", "/pub/openshift-v4/sources/packages/", delete_old=false)
-            }
-        }
-
         /*
          * This has inappropriate logic, disabling it for now.
          * Current behavior is to look up rhcos version of machine-os-content


### PR DESCRIPTION
move sync rhcos srpms step to python.
the sync rhocs srpms step is trying to solve an issue that RHCOS is not using a source from a standard released repo so we need to publish the unreleased srpms.
basically there are two way to handle it:
1 we can no do the sync step and enable this step when this issue happened to make RHCOS correct
2 we can also run this sync by default with filters to prevent this issue happen

this pr is using the 2 method, the filter is set to run the sync against all 4.13+ and not GA releases.