### PR TITLE
Move build-sync fail counter to Redis

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -202,61 +202,20 @@ node('covscan') {
 
         try {
             buildlib.withAppCiAsArtPublish() {
-                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN')]) {
+                withCredentials([
+                    string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                    string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
+                    string(credentialsId: 'redis-port', variable: 'REDIS_PORT')
+                ]) {
                     sh(script: cmd.join(' '), returnStdout: true)
                 }
             }
-
-            // Successful buildsync, reset fail count
-            writeFile file: failCountFile, text: "0"
 
             if (params.PUBLISH && !params.DRY_RUN) {
                 currentBuild.description += " [PUBLISH]"
             }
         } catch (err) {
-            failCount = 1
-            if (fileExists(failCountFile)) {
-                failCountStr = readFile(failCountFile).trim()
-                if (failCountStr.isInteger()) {
-                    failCount = failCountStr.toInteger() + 1
-                }
-            }
-            writeFile file: failCountFile, text: "${failCount}"
-
-            if (failCount > 1) {
-                msg = "Pipeline has failed to assemble release payload for ${BUILD_VERSION} (assembly ${ASSEMBLY}) ${failCount} times."
-                // TODO: https://issues.redhat.com/browse/ART-5657
-                artNotifyFrequency = 2
-                forumReleaseNotifyFrequency = 5
-                if (failCount > 10 && failCount <= 50) {
-                    artNotifyFrequency = 5
-                    forumReleaseNotifyFrequency = 10
-                }
-                if (failCount > 50 && failCount <= 200) {
-                    artNotifyFrequency = 10
-                    forumReleaseNotifyFrequency = 50
-                }
-                if (failCount > 200) {
-                    artNotifyFrequency = 100
-                    forumReleaseNotifyFrequency = 100
-                }
-                if (failCount % artNotifyFrequency == 0) {  // spam ourselves a little more often than forum-release
-                    slacklib.to(params.BUILD_VERSION).failure(msg)
-                }
-                if (assembly == "stream" && (failCount % forumReleaseNotifyFrequency == 0)) {
-                    def out = buildlib.doozer("--group=openshift-${params.BUILD_VERSION} config:read-group --yaml release_state",
-                                              [capture: true]).trim()
-                    def archReleaseStates = readYaml(text: out)
-                    if (archReleaseStates[BUILD_VERSION]['release'].isEmpty()) {
-                        // For development releases, notify TRT and release artists
-                        slacklib.to("#forum-release-oversight").failure("@release-artists ${msg}")
-                    } else {
-                        // For GA releases, let forum-release know why no new builds
-                        slacklib.to("#forum-release").failure(msg)
-                    }
-                }
-            }
-
             currentBuild.displayName += " [FAILURE]"
             commonlib.email(
                     to: "aos-art-automation+failed-build-sync@redhat.com",
@@ -273,11 +232,7 @@ node('covscan') {
             artifacts = []
             artifacts.addAll(["app.ci-backup.tgz", "gen-payload-artifacts/*", "MIRROR_working/debug.log"])
             commonlib.safeArchiveArtifacts(artifacts)
-
-            // Cleanup without calling cleanWorkspace as this will remove failure count
-            sh "rm -rf ${env.WORKSPACE}/doozer_working"
-            sh "rm -rf ${mirrorWorking}"
-            sh "rm -rf ${env.WORKSPACE}/gen-payload-artifacts"
+            buildlib.cleanWorkspace()
         }
     } // stage build-sync
 }

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -1,11 +1,8 @@
 import logging
-import os
-from string import Template
 
 from aioredlock import Aioredlock
 
-# Redis instance where lock are stored
-redis = Template('${protocol}://:${redis_password}@${redis_host}:${redis_port}')
+from pyartcd import redis
 
 # This constant defines for each lock type:
 # - how many times the lock manager should try to acquire the lock before giving up
@@ -69,14 +66,8 @@ def new_lock_manager(internal_lock_timeout=10.0, retry_count=3, retry_delay_min=
     Altogether, if the resource cannot be acquired in (retry_count * retry_delay), the lock operation will fail.
     """
 
-    redis_instance = redis.substitute(
-        protocol='rediss' if use_ssl else 'redis',
-        redis_password=os.environ['REDIS_SERVER_PASSWORD'],
-        redis_host=os.environ['REDIS_HOST'],
-        redis_port=os.environ['REDIS_PORT']
-    )
     return LockManager(
-        [redis_instance],
+        [redis.redis_url(use_ssl)],
         internal_lock_timeout=internal_lock_timeout,
         retry_count=retry_count,
         retry_delay_min=retry_delay_min

--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -8,6 +8,7 @@ import yaml
 
 from pyartcd.cli import cli, pass_runtime, click_coroutine
 from pyartcd.oc import registry_login
+from pyartcd.redis import RedisError
 from pyartcd.runtime import Runtime
 from pyartcd import exectools, constants, redis, util
 from pyartcd.util import branch_arches
@@ -384,3 +385,7 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
             else:
                 # For GA releases, let forum-release know why no new builds
                 slack_client.bind('#forum-release').say(msg)
+
+    except RedisError as e:
+        runtime.logger.error('Encountered error when updating the fail counter: %s', e)
+        raise

--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -1,0 +1,38 @@
+import os
+from string import Template
+
+import aioredis
+
+# Redis instance template, to be renderes with env vars
+redis = Template('${protocol}://:${redis_password}@${redis_host}:${redis_port}')
+
+
+def redis_url(use_ssl=True):
+    if not os.environ.get('REDIS_SERVER_PASSWORD', None):
+        raise RuntimeError('Please define REDIS_SERVER_PASSWORD env var')
+    if not os.environ.get('REDIS_HOST', None):
+        raise RuntimeError('Please define REDIS_HOST env var')
+    if not os.environ.get('REDIS_PORT', None):
+        raise RuntimeError('Please define REDIS_PORT env var')
+
+    return redis.substitute(
+        protocol='rediss' if use_ssl else 'redis',
+        redis_password=os.environ['REDIS_SERVER_PASSWORD'],
+        redis_host=os.environ['REDIS_HOST'],
+        redis_port=os.environ['REDIS_PORT']
+    )
+
+
+async def get_value(key: str, use_ssl: bool = True):
+    url = redis_url(use_ssl)
+    conn = await aioredis.create_redis(url, encoding="utf-8")
+    value = await conn.get(key)
+    conn.close()
+    return value
+
+
+async def set_value(key: str, value, use_ssl: bool = True):
+    url = redis_url(use_ssl)
+    conn = await aioredis.create_redis(url, encoding="utf-8")
+    await conn.set(key, value)
+    conn.close()

--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -7,13 +7,17 @@ import aioredis
 redis = Template('${protocol}://:${redis_password}@${redis_host}:${redis_port}')
 
 
+class RedisError(Exception):
+    pass
+
+
 def redis_url(use_ssl=True):
     if not os.environ.get('REDIS_SERVER_PASSWORD', None):
-        raise RuntimeError('Please define REDIS_SERVER_PASSWORD env var')
+        raise RedisError('Please define REDIS_SERVER_PASSWORD env var')
     if not os.environ.get('REDIS_HOST', None):
-        raise RuntimeError('Please define REDIS_HOST env var')
+        raise RedisError('Please define REDIS_HOST env var')
     if not os.environ.get('REDIS_PORT', None):
-        raise RuntimeError('Please define REDIS_PORT env var')
+        raise RedisError('Please define REDIS_PORT env var')
 
     return redis.substitute(
         protocol='rediss' if use_ssl else 'redis',


### PR DESCRIPTION
Tested on a 4.14 build-sync: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/build-sync/13/console