### PR TITLE
[ART-7039] provide client cert to rhsm-pulp

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -165,7 +165,17 @@ def setup_venv(use_python38=false) {
 }
 
 def doozer(cmd, opts=[:]){
-    withCredentials([usernamePassword(credentialsId: 'art-dash-db-login', passwordVariable: 'DOOZER_DB_PASSWORD', usernameVariable: 'DOOZER_DB_USER')]) {
+    withCredentials([
+        usernamePassword(
+            credentialsId: 'art-dash-db-login',
+            passwordVariable: 'DOOZER_DB_PASSWORD', usernameVariable: 'DOOZER_DB_USER'),
+        file(
+            credentialsId: 'art-jenkins-ldap-serviceaccount-private-key',
+            variable: 'RHSM_PULP_KEY')),
+        file(
+            credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert',
+            variable: 'RHSM_PULP_CERT')),
+    ]) {
         withEnv(['DOOZER_DB_NAME=art_dash']) {
             return commonlib.shell(
                 returnStdout: opts.capture ?: false,


### PR DESCRIPTION
Requires https://github.com/openshift-eng/doozer/pull/779
Provides credentials to doozer for RHSM pulp; but only for jobs that use the `buildlib.doozer` method -- anything that has been migrated to python would need updates to do the same.

Tests with ocp4 in two cases:
* [without specifying the credentials](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Focp4/58/console) (WARNING and validation skipped)
* [with the credentials](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-dev/job/dev-build%252Focp4/60/console) (no warning, fine until cancelled)