### PR TITLE
Revert "Doozer load releases"

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -69,10 +69,7 @@ class BuildMicroShiftPipeline:
         slack_client = None
         try:
             await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
-            releases_config = await load_releases_config(
-                group=self.group,
-                data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL
-            )
+            releases_config = await load_releases_config(Path(self._doozer_env_vars["DOOZER_WORKING_DIR"], "ocp-build-data"))
             assembly_type = get_assembly_type(releases_config, self.assembly)
             if assembly_type not in self.SUPPORTED_ASSEMBLY_TYPES:
                 raise ValueError(f"Building MicroShift for assembly type {assembly_type.value} is not currently supported.")

--- a/pyartcd/pyartcd/pipelines/promote.py
+++ b/pyartcd/pyartcd/pipelines/promote.py
@@ -91,10 +91,7 @@ class PromotePipeline:
         # Load group config and releases.yml
         logger.info("Loading build data...")
         group_config = await util.load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
-        releases_config = await util.load_releases_config(
-            group=self.group,
-            data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL
-        )
+        releases_config = await util.load_releases_config(self._doozer_working_dir / "ocp-build-data")
         if releases_config.get("releases", {}).get(self.assembly) is None:
             raise ValueError(f"To promote this release, assembly {self.assembly} must be explictly defined in releases.yml.")
         permits = util.get_assembly_promotion_permits(releases_config, self.assembly)

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -69,10 +69,7 @@ class RebuildPipeline:
         release = f"{timestamp}.p?"
 
         group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
-        releases_config = await load_releases_config(
-            group=self.group,
-            data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL
-        )
+        releases_config = await load_releases_config(Path(self._doozer_env_vars["DOOZER_WORKING_DIR"], "ocp-build-data"))
 
         if get_assembly_type(releases_config, self.assembly) == AssemblyTypes.STREAM:
             raise ValueError("You may not rebuild a component for a stream assembly.")

--- a/pyartcd/pyartcd/util.py
+++ b/pyartcd/pyartcd/util.py
@@ -101,42 +101,12 @@ async def load_group_config(group: str, assembly: str, env=None,
     return group_config
 
 
-async def load_releases_config(group: str, data_path: str = constants.OCP_BUILD_DATA_URL) -> Optional[Dict]:
-    cmd = [
-        'doozer',
-        f'--data-path={data_path}',
-        f'--group={group}',
-        'config:read-releases',
-        '--yaml'
-    ]
-
+async def load_releases_config(build_data_path: os.PathLike) -> Optional[Dict]:
     try:
-        _, out, _ = await exectools.cmd_gather_async(cmd)
-        return yaml.safe_load(out.strip())
-
-    except ChildProcessError as e:
-        logger.error('Command "%s" failed: %s', ' '.join(cmd), e)
-        return None
-
-
-async def load_assembly(group: str, assembly: str, key: str = '',
-                        data_path: str = constants.OCP_BUILD_DATA_URL) -> Optional[Dict]:
-    cmd = [
-        'doozer',
-        f'--data-path={data_path}',
-        f'--group={group}',
-        'config:read-assembly',
-        f'--assembly={assembly}',
-        '--yaml',
-        key
-    ]
-
-    try:
-        _, out, _ = await exectools.cmd_gather_async(cmd)
-        return yaml.safe_load(out.strip())
-
-    except ChildProcessError as e:
-        logger.error('Command "%s" failed: %s', ' '.join(cmd), e)
+        async with aiofiles.open(Path(build_data_path) / "releases.yml", "r") as f:
+            content = await f.read()
+        return yaml.safe_load(content)
+    except FileNotFoundError:
         return None
 
 


### PR DESCRIPTION
Reverts openshift-eng/aos-cd-jobs#3748

Assuming this is causing:

https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fpromote-assembly/746/console
```
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/art-venv/bin/artcd", line 33, in <module>
    sys.exit(load_entry_point('pyartcd', 'console_scripts', 'artcd')())
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/pyartcd/pyartcd/__main__.py", line 12, in main
    cli()
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/jenkins/.local/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/pyartcd/pyartcd/cli.py", line 20, in wrapper
    return loop.run_until_complete(f(*args, **kwargs))
  File "/opt/rh/rh-python38/root/usr/lib64/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/pyartcd/pyartcd/pipelines/promote.py", line 1236, in promote
    await pipeline.run()
  File "/mnt/workspace/jenkins/working/cd-builds_build_promote-assembly/pyartcd/pyartcd/pipelines/promote.py", line 98, in run
    if releases_config.get("releases", {}).get(self.assembly) is None:
AttributeError: 'NoneType' object has no attribute 'get'
```