### PR TITLE
Skip plugin when current version is higher than what's required

### DIFF
--- a/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
+++ b/hacks/update-jenkins-plugins/collect-jenkins-plugins.sh
@@ -148,6 +148,10 @@ get_plugin() {
             echo "Skipping already existing plugin: ${plugin}:${existing_version}"
             return 0
         fi
+        if [ $(echo "${existing_version}" | cut -d "." -f 1) > $(echo "${PLUGIN_VERSION}" | cut -d "." -f 1) ]; then
+            echo "Skipping due to existing plugin: ${plugin}:${existing_version} higher than ${PLUGIN_VERSION}"
+            return 0
+        fi
 
         # If the version is opinionated, let the human resolve it
         if [ ! -z "${plugin_version}" ]; then
@@ -209,4 +213,3 @@ for vf in ${tmp_hpis_dir}/*.version; do
 done
 
 exit 0
-


### PR DESCRIPTION
Currently, we are skipping plugin collection only if the minimal depended version matches what we're already collecting. This causes conflicts like this:
```
Unable to resolve dependency version conflict:
ionicons-api:31.v4757b_6987003 conflicts with existing 56.v1b_1c8c49374e 
```
According to [this comment](https://issues.redhat.com/browse/ART-7121?focusedId=22494053&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22494053), we just need to make sure we're collecting a version high enough to satisfy the dependency requirements. 