### PR TITLE
[build-sync] Fix release state check

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_sync.py
+++ b/pyartcd/pyartcd/pipelines/build_sync.py
@@ -381,7 +381,7 @@ async def build_sync(runtime: Runtime, version: str, assembly: str, publish: boo
         if fail_count % forum_release_notify_frequency == 0:
             group_config = await util.load_group_config(group=f'openshift-{version}', assembly=assembly)
 
-            if not group_config['release_state'][version]['release']:
+            if not group_config['release_state']['release']:
                 # For development releases, notify TRT and release artists
                 slack_client.bind('#forum-release-oversight').say(msg)
 


### PR DESCRIPTION
[failure](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/33973/console)

```
File "/mnt/workspace/jenkins_agent/workspace/aos-cd-builds_build_build-sync/pyartcd/pyartcd/pipelines/build_sync.py", line 384, in build_sync
    if not group_config['release_state'][version]['release']:
KeyError: '4.13'
```