### PR TITLE
Do not scan sources again in ocp4 when not needed

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -55,8 +55,8 @@ node {
                         trim: true,
                     ),
                     booleanParam(
-                        name: 'FORCE_BUILD',
-                        description: 'Build regardless of whether source has changed',
+                        name: 'PIN_BUILDS',
+                        description: 'Build only specified rpms/images regardless of whether source has changed',
                         defaultValue: false,
                     ),
                     choice(

--- a/jobs/build/ocp4/build.groovy
+++ b/jobs/build/ocp4/build.groovy
@@ -19,7 +19,7 @@ allImagebuildfailed = false
 buildPlan = [
     activeImageCount: 1, // number of images active in this version
     dryRun: false, // report build plan without performing it
-    forceBuild: false, // build regardless of whether source has changed
+    pinBuild: false, // build specified rpms/images regardless of whether source has changed
     buildRpms: false,
     rpmsIncluded: "", // comma-separated list
     rpmsExcluded: "", // comma-separated list
@@ -63,7 +63,7 @@ def initialize() {
 
     buildPlan << [
         dryRun: params.DRY_RUN,
-        forceBuild: params.FORCE_BUILD,
+        pinBuild: params.PIN_BUILDS,
         buildRpms: params.BUILD_RPMS != "none",
         buildImages: params.BUILD_IMAGES != "none",
     ]
@@ -91,7 +91,6 @@ def initialize() {
     // adjust the build "title"
     currentBuild.displayName = "#${currentBuild.number} - ${version.stream}-${version.release}"
     if (buildPlan.dryRun) { currentBuild.displayName += " [DRY RUN]" }
-    if (buildPlan.forceBuild) { currentBuild.displayName += " [force build]" }
     if (!buildPlan.buildRpms) { currentBuild.displayName += " [no RPMs]" }
     if (!buildPlan.buildImages) { currentBuild.displayName += " [no images]" }
 
@@ -100,7 +99,7 @@ def initialize() {
     echo """Updated build plan: [
 activeImageCount: ${buildPlan.activeImageCount}
 dryRun: ${buildPlan.dryRun}
-forceBuild: ${buildPlan.forceBuild}
+pinBuild: ${buildPlan.pinBuild}
 buildRpms: ${buildPlan.buildRpms}
 rpmsIncluded: ${buildPlan.rpmsIncluded}
 rpmsExcluded: ${buildPlan.rpmsExcluded}
@@ -140,8 +139,8 @@ def displayTagFor(commaList, kind, isExcluded=false){
  * @return map which is the buildPlan property of this build.
  */
 def planBuilds() {
-    if (buildPlan.forceBuild) {
-        currentBuild.description += "Force building (whether source changed or not).<br/>"
+    if (buildPlan.pinBuild) {
+        currentBuild.description += "Pin rpms/images to build (whether source changed or not).<br/>"
         currentBuild.description +=
             (!buildPlan.buildRpms) ? "RPMs: not building.<br/>" :
             (buildPlan.rpmsIncluded) ? "RPMs: building ${buildPlan.rpmsIncluded}.<br/>" :

--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -123,10 +123,30 @@ def start_build(job_name: str, params: dict, blocking: bool = False,
         return result
 
 
-def start_ocp4(build_version: str, blocking: bool = False) -> Optional[str]:
+def start_ocp4(build_version: str, rpm_list: list = [], image_list: list = [], blocking: bool = False) -> Optional[str]:
+    params = {'BUILD_VERSION': build_version}
+
+    # If any rpm/image changed, force a build with only changed sources
+    if rpm_list or image_list:
+        params['FORCE_BUILD'] = True
+
+    # Build only changed RPMs or none
+    if rpm_list:
+        params['BUILD_RPMS'] = 'only'
+        params['RPM_LIST'] = ','.join(rpm_list)
+    else:
+        params['BUILD_RPMS'] = 'none'
+
+    # Build only changed images or none
+    if image_list:
+        params['BUILD_IMAGES'] = 'only'
+        params['IMAGE_LIST'] = ','.join(image_list)
+    else:
+        params['BUILD_IMAGES'] = 'none'
+
     return start_build(
         job_name=Jobs.OCP4.value,
-        params={'BUILD_VERSION': build_version},
+        params=params,
         blocking=blocking
     )
 

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -48,7 +48,12 @@ class Ocp4ScanPipeline:
 
             # Trigger ocp4
             self.logger.info('Triggering a %s ocp4 build', self.version)
-            jenkins.start_ocp4(build_version=self.version, blocking=False)
+            jenkins.start_ocp4(
+                build_version=self.version,
+                blocking=False,
+                rpm_list=self.changes.get('rpms', []),
+                image_list=self.changes.get('images', []),
+            )
 
         elif self.rhcos_inconsistent:
             self.logger.info('Detected inconsistent RHCOS RPMs:\n%s', self.inconsistent_rhcos_rpms)


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-7154

`ocp4-scan` already detects source changes by calling `doozer config:scan-sources`. If changes are detected, `ocp4` is triggered. Then, `doozer config:scan-sources` will be called again with very little latency compared to the first time, so it's very likely that it will produce the same results.

This PR proposes to skip `doozer config:scan-sources` in ocp4 when triggered by automation, by providing it with changed sources in the form of a forced build with a predefined rpm/image list. This way, we will not plan builds again.

This has the advantage of saving build time and resources (Brew API consumption).