### PR TITLE
Minor ocp4 improvements

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -579,7 +579,7 @@ class Ocp4Pipeline:
 
         failed_images = list(failed_map.keys())
         run_details.update_status('UNSTABLE')
-        run_details.update_description(f'Failed images: f{", ".join(failed_images)}<br/>')
+        run_details.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
         self.runtime.logger.warning('Failed images: %s', ', '.join(failed_images))
 
         ratio = record_util.determine_build_failure_ratio(record_log)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -597,7 +597,12 @@ class Ocp4Pipeline:
 
         failed_images = list(failed_map.keys())
         run_details.update_status('UNSTABLE')
-        run_details.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
+
+        if len(failed_images) <= 10:
+            run_details.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
+        else:
+            run_details.update_description(f'{len(failed_images)} images failed. Check record.log for details/>')
+
         self.runtime.logger.warning('Failed images: %s', ', '.join(failed_images))
 
         ratio = record_util.determine_build_failure_ratio(record_log)

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -234,7 +234,11 @@ class Ocp4Pipeline:
             run_details.update_description('Mass image rebuild (more than half) - invoking serializing semaphore')
 
         elif self.build_plan.images_included:
-            run_details.update_description(f'Images: building {self.build_plan.images_included}.<br/>')
+            images_to_build = len(self.build_plan.images_included)
+            if images_to_build <= 10:
+                run_details.update_description(f'Images: building {self.build_plan.images_included}.<br/>')
+            else:
+                run_details.update_description(f'Images: building {images_to_build} images.<br/>')
 
         elif self.build_plan.images_excluded:
             run_details.update_description(f'Images: building all except {self.build_plan.images_excluded}.<br/>')

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -231,6 +231,7 @@ class Ocp4Pipeline:
             run_details.update_description('Images: not building.<br/>')
 
         elif self.mass_rebuild:
+            run_details.update_title(' [mass rebuild]')
             run_details.update_description('Mass image rebuild (more than half) - invoking serializing semaphore')
 
         elif self.build_plan.images_included:


### PR DESCRIPTION
- In case of mass rebuilds, do not log the building images in the job description. Prevent failures [like this](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1689195187809179?thread_ts=1689192255.840979&cid=GDBRP5YJH)
- Remove an extra `f` when logging failed images