### PR TITLE
Fix client promotion for 4.6/4.7

### DIFF
--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -76,7 +76,7 @@ node {
                         ),
                         string(
                             name: 'PREVIOUS',
-                            description: '[Optional] Leave empty to use suggested previous. Otherwise, follow item #6 "PREVIOUS" of the following doc for instructions on how to fill this field:\nhttps://mojo.redhat.com/docs/DOC-1201843#jive_content_id_Completing_a_4yz_release',
+                            description: '[Optional] Leave empty to use suggested previous. "none" for no previous. Otherwise, follow item #6 "PREVIOUS" of the following doc for instructions on how to fill this field:\nhttps://mojo.redhat.com/docs/DOC-1201843#jive_content_id_Completing_a_4yz_release',
                             defaultValue: "",
                             trim: true,
                         ),

--- a/pyartcd/pyartcd/constants.py
+++ b/pyartcd/pyartcd/constants.py
@@ -17,11 +17,13 @@ NIGHTLY_PAYLOAD_REPOS = {
     "ppc64le": "registry.ci.openshift.org/ocp-ppc64le/release-ppc64le",
     "aarch64": "registry.ci.openshift.org/ocp-arm64/release-arm64",
 }
-# The client name mapping in nightly with name on mirror
+
+# Maps the name of a release component tag to the filename element to include
+# when creating artifacts on mirror.openshift.com.
 MIRROR_CLIENTS = {
-    "oc": "openshift-client",
+    "cli": "openshift-client",
     "installer": "openshift-installer",
-    "operator-framework-olm": "opm",
+    "operator-registry": "opm",
 }
 
 OCP_BUILD_DATA_URL = 'https://github.com/openshift-eng/ocp-build-data'


### PR DESCRIPTION
In 4.6 and 4.7, the source for OLM was a different repository (`https://github.com/operator-framework/operator-registry` vs `https://github.com/openshift/operator-framework-olm`). It was not present in MIRROR_CLIENTS map and caused a failure. Making this logic upstream agnostic.