### PR TITLE
[rebuild] Provide token and data path to all doozer invokes

### DIFF
--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -105,7 +105,10 @@ node {
                 cmd << params.DISTGIT_KEY
             }
             sshagent(["openshift-bot"]) {
-                withCredentials([string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN')]) {
+                withCredentials([
+                    string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN'),
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')
+                ]) {
                     echo "Will run ${cmd}"
                     if (params.IGNORE_LOCKS) {
                         commonlib.shell(script: cmd.join(' '))

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -107,13 +107,22 @@ node {
             sshagent(["openshift-bot"]) {
                 withCredentials([
                     string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN'),
-                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                    usernamePassword(credentialsId: 'art-dash-db-login', passwordVariable: 'DOOZER_DB_PASSWORD', usernameVariable: 'DOOZER_DB_USER'),
+                    file(credentialsId: 'art-jenkins-ldap-serviceaccount-private-key', variable: 'RHSM_PULP_KEY'),
+                    file(credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert', variable: 'RHSM_PULP_CERT'),
                 ]) {
                     echo "Will run ${cmd}"
-                    if (params.IGNORE_LOCKS) {
+                    if (!params.IGNORE_LOCKS) {
+                        lock("github-activity-lock-${params.BUILD_VERSION}")
+                    }
+                    withEnv([
+                        "BUILD_USER_EMAIL=${builderEmail?: ''}",
+                        "BUILD_URL=${BUILD_URL}",
+                        "JOB_NAME=${JOB_NAME}",
+                        'DOOZER_DB_NAME=art_dash'
+                    ]) {
                         commonlib.shell(script: cmd.join(' '))
-                    } else {
-                        lock("github-activity-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
                     }
                 }
             }

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -192,7 +192,6 @@ class Ocp4Pipeline:
             (exclude_count and self.build_plan.active_image_count > exclude_count * 2) or \
             (not include_count and not exclude_count)
 
-
     async def _initialize(self):
         await self._check_assembly()
         await self._initialize_version()

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -61,7 +61,8 @@ class RebuildPipeline:
         self._doozer_env_vars["DOOZER_WORKING_DIR"] = str(self.runtime.working_dir / "doozer-working")
 
         if not ocp_build_data_url:
-            ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url")
+            ocp_build_data_url = self.runtime.config.get("build_config", {}).get("ocp_build_data_url",
+                                                                                 constants.OCP_BUILD_DATA_URL)
         if ocp_build_data_url:
             self._doozer_env_vars["DOOZER_DATA_PATH"] = ocp_build_data_url
 
@@ -69,7 +70,8 @@ class RebuildPipeline:
         timestamp = datetime.utcnow().strftime("%Y%m%d%H%M")
         release = f"{timestamp}.p?"
 
-        group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
+        group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars,
+                                               doozer_data_path=self.ocp_build_data_url)
         releases_config = await load_releases_config(
             group=self.group,
             data_path=self.ocp_build_data_url

--- a/pyartcd/pyartcd/pipelines/rebuild.py
+++ b/pyartcd/pyartcd/pipelines/rebuild.py
@@ -48,6 +48,7 @@ class RebuildPipeline:
         self.type = type
         self.dg_key = dg_key
         self.logger = logger or runtime.logger
+        self.ocp_build_data_url = ocp_build_data_url
 
         # determines OCP version
         match = re.fullmatch(r"openshift-(\d+).(\d+)", group)
@@ -71,7 +72,7 @@ class RebuildPipeline:
         group_config = await load_group_config(self.group, self.assembly, env=self._doozer_env_vars)
         releases_config = await load_releases_config(
             group=self.group,
-            data_path=self._doozer_env_vars.get("DOOZER_DATA_PATH", None) or constants.OCP_BUILD_DATA_URL
+            data_path=self.ocp_build_data_url
         )
 
         if get_assembly_type(releases_config, self.assembly) == AssemblyTypes.STREAM:
@@ -174,6 +175,7 @@ class RebuildPipeline:
         signing_mode = "signed"  # We assume rpms used in rebuild job should be always signed
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "config:plashet",
@@ -233,6 +235,7 @@ class RebuildPipeline:
         signing_mode = "signed"  # We assume rpms used in rebuild job should be always signed
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "config:plashet",
@@ -437,6 +440,7 @@ class RebuildPipeline:
         self.logger.info("Determining distgit branch for image %s...", self.dg_key)
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "-i", self.dg_key,
@@ -456,6 +460,7 @@ class RebuildPipeline:
         version = f"v{major}.{minor}"
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "--latest-parent-version",
@@ -478,6 +483,7 @@ class RebuildPipeline:
         # build
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "--latest-parent-version",
@@ -505,6 +511,7 @@ class RebuildPipeline:
         major, minor = self._ocp_version
         cmd = [
             "doozer",
+            "--data-path", self.ocp_build_data_url,
             "--group", self.group,
             "--assembly", self.assembly,
             "-r", self.dg_key,


### PR DESCRIPTION
## Summary
- Provide github token to rebuild job (this not being there right now breaks the job completely)
- Provide env vars and credentials for doozer to record builds into db
- Provide data path in rebuild job to all doozer invokes

## Test run
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frebuild/19/console