### PR TITLE
Add retry to art-attention job

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
+++ b/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
@@ -15,7 +15,9 @@ node() {
                             string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
                             string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
                         ]) {
-            commonlib.shell(script: "scl enable rh-python38 -- scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py")
+            retry(3) {
+                commonlib.shell(script: "scl enable rh-python38 -- scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py")
+            }
         }
     } catch (e) {
         slacklib.to('#team-art').say("Error while checking unresolved threads: ${env.BUILD_URL}")


### PR DESCRIPTION
Getting `urllib.error.URLError: <urlopen error [Errno 113] No route to host>` possible due to the DNS being flaky. Usually works when we rerun the job.