### PR TITLE
Revert "Revert "Bump early operator index to track 4.15""

### DIFF
--- a/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
+++ b/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
@@ -17,9 +17,9 @@ node {
 
     workDir = "${env.WORKSPACE}/doozer_working"
     sh "rm -rf ${workDir}"
-    ocpVer = "4.14"
-    operatorIndexBaseVersion = "4.13"
-    operatorRegistryVersion = "4.13"
+    ocpVer = "4.15"
+    operatorIndexBaseVersion = "4.14"
+    operatorRegistryVersion = "4.14"
     
     // Print out bundle pullspecs alongside of distgit keys to help identify bundles which have not been built yet.
     echo "Doozer pullspecs by distgit_key"


### PR DESCRIPTION
Reverts openshift-eng/aos-cd-jobs#3808
we can bump the version now https://redhat-internal.slack.com/archives/CB95J6R4N/p1689961558069079?thread_ts=1689344539.118619&cid=CB95J6R4N