### PR TITLE
[ART-7236] call advisory drop from pyartcd

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -45,16 +45,21 @@ node {
     }
 
     advisory_list = commonlib.parseList(params.ADVISORIES)
+    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
 
     for(adv in advisory_list) {
-        def elliott = "${buildlib.ELLIOTT_BIN} --group=openshift-${params.VERSION}"
+        def cmd = [
+            "artcd",
+            "-v",
+            "--working-dir=./artcd_working",
+            "--config=./config/artcd.toml",
+            "advisory-drop",
+            "--group=openshift-${params.VERSION}",
+            "--advisory", adv,
+            "--comment", params.COMMENT,
+        ]
         withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
-            commonlib.shell(
-                script: """
-                ${elliott} repair-bugs --advisory ${adv} --auto --comment "${comment}" --close-placeholder --from RELEASE_PENDING --to VERIFIED
-                ${elliott} advisory-drop ${adv}
-                """,
-            )
+            commonlib.shell(script: cmd.join(' '))
         }
     }
 

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, custom, scan_for_kernel_bugs, tag_rpms
+    olm_bundle, ocp4, custom, scan_for_kernel_bugs, tag_rpms, advisory_drop
 )
 
 

--- a/pyartcd/pyartcd/pipelines/advisory_drop.py
+++ b/pyartcd/pyartcd/pipelines/advisory_drop.py
@@ -1,0 +1,33 @@
+import click
+import os
+from pyartcd.runtime import Runtime
+from pyartcd import exectools
+
+@cli.command('advisory-drop')
+@click.option('--group', required=True, help='OCP group')
+@click.option('--advisory', required=True, help='Advisory number')
+@click.option('--comment', required=False, default="This bug will be dropped from current advisory because the advisory will also be dropped and not going to be shipped.",
+              help='Comment will add to the bug attached on the advisory to explain the reason')
+@pass_runtime
+@click_coroutine
+async def advisory_drop(runtime: Runtime, group: str, advisory: str, comment: str):
+    # repair-bugs
+    cmd = [
+            'elliott',
+            '--group', group,
+            'repair-bugs',
+            '--advisory', advisory,
+            '--auto',
+            '--comment', comment,
+            '--close-placeholder',
+            '--from', 'RELEASE_PENDING',
+            '--to', 'VERIFIED',
+        ]
+    await exectools.cmd_assert_async(cmd, env=os.environ.copy())
+    # drop advisory
+    cmd = [
+            'elliott',
+            '--group', group,
+            'advisory-drop', advisory,
+        ]
+    await exectools.cmd_assert_async(cmd, env=os.environ.copy())


### PR DESCRIPTION
drop advisory job only contains two elliott cmd, so migrate the job to python is to call them from pyartcd.