### PR TITLE
ART-7334 mark ocp4 as unstable on failed builds

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -182,6 +182,16 @@ node {
                                 ]) {
                             withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
                                 sh(script: cmd.join(' '), returnStdout: true)
+
+                                // If any image build/push failures occurred, mark the job run as unstable
+                                def record_log = buildlib.parse_record_log(doozer_working)
+                                builds = record_log.get('build', [])
+                                for (i = 0; i < builds.size(); i++) {
+                                    bld = builds[i]
+                                    if (bld['status'] != '0' || bld['push_status'] != '0') {
+                                        currentBuild.result = "UNSTABLE"
+                                    }
+                                }
                             }
                         }
                     }

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -596,9 +596,7 @@ class Ocp4Pipeline:
         if not failed_map:
             # failed so badly we don't know what failed; give up
             raise
-
         failed_images = list(failed_map.keys())
-        run_details.update_status('UNSTABLE')
 
         if len(failed_images) <= 10:
             run_details.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
@@ -773,8 +771,6 @@ class Ocp4Pipeline:
             await exectools.cmd_assert_async(cmd)
 
         except ChildProcessError:
-            run_details.update_status('UNSTABLE')
-
             if self.runtime.dry_run:
                 return
 

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -235,7 +235,7 @@ class Ocp4Pipeline:
 
         elif self.mass_rebuild:
             run_details.update_title(' [mass rebuild]')
-            run_details.update_description('Mass image rebuild (more than half) - invoking serializing semaphore')
+            run_details.update_description('Mass image rebuild (more than half) - invoking serializing semaphore<br/>')
 
         elif self.build_plan.images_included:
             images_to_build = len(self.build_plan.images_included)
@@ -603,7 +603,7 @@ class Ocp4Pipeline:
         if len(failed_images) <= 10:
             run_details.update_description(f'Failed images: {", ".join(failed_images)}<br/>')
         else:
-            run_details.update_description(f'{len(failed_images)} images failed. Check record.log for details/>')
+            run_details.update_description(f'{len(failed_images)} images failed. Check record.log for details<br/>')
 
         self.runtime.logger.warning('Failed images: %s', ', '.join(failed_images))
 
@@ -800,7 +800,7 @@ class Ocp4Pipeline:
                             f'Elapsed image build time: {metrics[0]["elapsed_total_minutes"]} minutes\n' \
                             f'Time spent waiting for OSBS capacity: {metrics[0]["elapsed_wait_minutes"]} minutes'
 
-        run_details.update_description(f'<hr />Build results:<br/><br/>{timing_report}')
+        run_details.update_description(f'<hr />Build results:<br/><br/>{timing_report}<br/>')
 
     async def run(self):
         await self._initialize()

--- a/pyartcd/pyartcd/run_details.py
+++ b/pyartcd/pyartcd/run_details.py
@@ -82,25 +82,3 @@ def update_description(description: str, append: bool = True):
         data="",
         valid=[200]
     )
-
-
-@check_env_vars
-def update_status(status: str):
-    """
-    Set build status to <status>
-    """
-
-    job = jenkins.jenkins_client.get_job(job_name)
-    build = Build(
-        url=build_url.replace(constants.JENKINS_UI_URL, constants.JENKINS_SERVER_URL),
-        buildno=int(list(filter(None, build_url.split('/')))[-1]),
-        job=job
-    )
-
-    data = {'json': f'{{"result":"{status}"}}'}
-    headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Referer': f"{build.baseurl}/configure"}
-    build.job.jenkins.requester.post_url(
-        f'{build.baseurl}/configSubmit',
-        params=data,
-        data='',
-        headers=headers)


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-7334

Updating Jenkins result from pyartcd does not seem to be working. Let's move back this piece of logic into Jenkinsfile