### PR TITLE
ocp4 - pin builds by default

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -57,7 +57,7 @@ node {
                     booleanParam(
                         name: 'PIN_BUILDS',
                         description: 'Build only specified rpms/images regardless of whether source has changed',
-                        defaultValue: false,
+                        defaultValue: true,
                     ),
                     choice(
                         name: 'BUILD_RPMS',


### PR DESCRIPTION
Pinning by default will avoid unintentional mass rebuilds