### PR TITLE
Add warning for PIN_BUILDS and set default to true

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -56,7 +56,7 @@ node {
                     ),
                     booleanParam(
                         name: 'PIN_BUILDS',
-                        description: 'Build only specified rpms/images regardless of whether source has changed. WARNING: Enable this if you don't want scan sources to run, like if you're testing for new release 4.x for branch cut',
+                        description: 'Build only specified rpms/images regardless of whether source has changed. WARNING: Disable this to use scan-sources as the source',
                         defaultValue: true,
                     ),
                     choice(

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -56,8 +56,8 @@ node {
                     ),
                     booleanParam(
                         name: 'PIN_BUILDS',
-                        description: 'Build only specified rpms/images regardless of whether source has changed',
-                        defaultValue: false,
+                        description: 'Build only specified rpms/images regardless of whether source has changed. WARNING: Enable this if you don't want scan sources to run, like if you're testing for new release 4.x for branch cut',
+                        defaultValue: true,
                     ),
                     choice(
                         name: 'BUILD_RPMS',


### PR DESCRIPTION
Scan sources will automatically run otherwise and can cause mass rebuilds, if we are testing.