### PR TITLE
[ocp4 images:rebuild] remove stray '' for exclude

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -324,7 +324,7 @@ class Ocp4Pipeline:
             return ['--latest-parent-version', f'--{kind}', ','.join(includes)]
 
         if excludes:
-            return ['--latest-parent-version', f"--{kind}=''", '--exclude', ','.join(excludes)]
+            return ['--latest-parent-version', f"--{kind}=", '--exclude', ','.join(excludes)]
 
         return [f'--{kind}=']
 

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -565,7 +565,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
             [
                 'doozer', '--assembly=stream', '--working-dir=doozer_working',
                 '--data-path=https://github.com/openshift-eng/ocp-build-data', '--group=openshift-4.13',
-                '--latest-parent-version', "--images=''", '--exclude', 'image1,image2,image3', 'images:build',
+                '--latest-parent-version', "--images=", '--exclude', 'image1,image2,image3', 'images:build',
                 '--repo-type', 'signed'
             ]
         )
@@ -1049,7 +1049,7 @@ class TestUtils(unittest.IsolatedAsyncioTestCase):
             includes=[],
             excludes=['image3', 'image4']
         )
-        self.assertEqual(include_exclude, ['--latest-parent-version', "--images=''", '--exclude', 'image3,image4'])
+        self.assertEqual(include_exclude, ['--latest-parent-version', "--images=", '--exclude', 'image3,image4'])
 
         # Include and exclude images: includes take precedence
         include_exclude = self.ocp4._include_exclude(


### PR DESCRIPTION
--images='' will cause doozer `--exclude` option to break