### PR TITLE
delete microshift auto pin branch after merged

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -396,10 +396,12 @@ class BuildMicroShiftPipeline:
             if not existing_prs.items:
                 result = api.pulls.create(head=head, base=base, title=title, body=body, maintainer_can_modify=True)
                 api.pulls.merge(owner=owner, repo=repo, pull_number=result.number, merge_method="squash")
+                api.git.delete_ref(owner=owner,repo=repo,ref=f"heads/{branch}")
             else:
                 pull_number = existing_prs.items[0].number
                 result = api.pulls.update(pull_number=pull_number, title=title, body=body)
                 api.pulls.merge(owner=owner, repo=repo, pull_number=pull_number, merge_method="squash")
+                api.git.delete_ref(owner=owner,repo=repo,ref=f"heads/{branch}")
         else:
             self._logger.warning("PR is not created: Nothing to commit.")
         return result


### PR DESCRIPTION
pin microshift pr is auto-merged, its not useful to keep the ephemeral branch