### PR TITLE
Provide prepare-release with a custom Elliott param

### DIFF
--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -27,6 +27,7 @@ node {
                     $class: "ParametersDefinitionProperty",
                     parameterDefinitions: [
                         commonlib.ocpVersionParam('VERSION'),
+                        commonlib.elliottParam(),
                         string(
                             name: "ASSEMBLY",
                             description: "The name of an assembly; must be defined in releases.yml (e.g. 4.9.1)",

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -151,10 +151,18 @@ def setup_venv(use_python38=false) {
     env.PATH = "${VIRTUAL_ENV}/bin:${env.WORKSPACE}/art-tools/elliott:${env.WORKSPACE}/art-tools/doozer:${env.PATH}"
 
     commonlib.shell(script: "pip install --upgrade pip")
+
+    // Override Doozer submodule
     if (params.DOOZER_COMMIT) {
         where = DOOZER_COMMIT.split('@')
         commonlib.shell(script: "rm -rf art-tools/doozer ; cd art-tools; git clone https://github.com/${where[0]}/doozer.git; cd doozer; git checkout ${where[1]}")
     }
+    // Override Elliott submodule
+    if (params.ELLIOTT_COMMIT) {
+        where = ELLIOTT_COMMIT.split('@')
+        commonlib.shell(script: "rm -rf art-tools/elliott ; cd art-tools; git clone https://github.com/${where[0]}/elliott.git; cd elliott; git checkout ${where[1]}")
+    }
+
     commonlib.shell(script: "pip install -e art-tools/elliott/ -e art-tools/doozer/ -e pyartcd/")
     out = sh(
         script: 'pip list | grep "doozer\\|elliott"',

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -101,6 +101,15 @@ def doozerParam() {
     ]
 }
 
+def elliottParam() {
+    return [
+        name: 'ELLIOTT_COMMIT',
+        description: 'Override the elliott submodule; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2',
+        $class: 'hudson.model.StringParameterDefinition',
+        defaultValue: ''
+    ]
+}
+
 def dryrunParam(description = 'Run job without side effects') {
     return [
         name: 'DRY_RUN',


### PR DESCRIPTION
During release preparation, if something's wrong with latest Elliott commits, we have not other ways than rollback to a previous commit or run tests in hack spaces. This PR proposes to give us the chance of pinning prepare-release to a previous Elliott commit