### PR TITLE
build-microshift: Add missing environment variables

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -106,7 +106,13 @@ node {
                 if (params.NO_REBASE) {
                     cmd << "--no-rebase"
                 }
-                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'), string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')]) {
+                withCredentials([
+                    string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                ]) {
                     echo "Will run ${cmd}"
                     if (params.IGNORE_LOCKS) {
                         commonlib.shell(script: cmd.join(' '))


### PR DESCRIPTION
JENKINS_SERVICE_ACCOUNT and JENKINS_SERVICE_ACCOUNT_TOKEN are now required for build-microshift to trigger microshift_sync job.