### PR TITLE
Remove duplicated messages

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
+++ b/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
@@ -34,15 +34,6 @@ if __name__ == '__main__':
         messages = slack_response.get('messages', {})
         all_matches.extend(messages.get('matches', []))
 
-        # API call doesn't return messages sent by the bot unless specified
-        slack_response = app.client.search_messages(
-            token=USER_TOKEN,
-            query='has::art-attention: -has::art-attention-resolved: from:art-release-bot',
-            cursor=next_cursor
-        )
-        messages = slack_response.get('messages', {})
-        all_matches.extend(messages.get('matches', []))
-
         # https://api.slack.com/docs/pagination
         response_metadata = slack_response.get('response_metadata', {})
         next_cursor = response_metadata.get('next_cursor', None)


### PR DESCRIPTION
Something has changed in slack API, messages sent by the bot are now being scanned by default. Removing the dedicated query to avoid duplicated messages