### PR TITLE
Fix advisory-drop

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -56,7 +56,7 @@ node {
             "advisory-drop",
             "--group=openshift-${params.VERSION}",
             "--advisory", adv,
-            "--comment", params.COMMENT,
+            "--comment='${params.COMMENT}'"
         ]
         withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
             commonlib.shell(script: cmd.join(' '))


### PR DESCRIPTION
Fixes this error:
```
Error: Got unexpected extra arguments (bug will be dropped from current advisory because the advisory will also be dropped and not going to be shipped.)
```

Test run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/advisory-drop/6/console
