### PR TITLE
Signing: Fix unexpected "Connection lost" error

### DIFF
--- a/pyartcd/pyartcd/umb_client.py
+++ b/pyartcd/pyartcd/umb_client.py
@@ -169,7 +169,7 @@ class UMBClientConnectionListener(stomp.ConnectionListener):
         self._client.on_disconnected()
         # notify all pending futures of the disconnection
         for future_id in self._futures.keys():
-            if id == "on_disconnected":
+            if future_id == "on_disconnected":
                 self._complete_future("on_disconnected", None)
             else:
                 self._err_future(future_id, IOError("Connection lost"))


### PR DESCRIPTION
Local variable `id` was renamed to `future_id` for better readability, but this place was forgotten.