### PR TITLE
ART-7242 port github-activity-lock into pyartcd

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -180,6 +180,9 @@ node {
                 if (params.SKIP_PLASHETS) {
                     cmd << "--skip-plashets"
                 }
+                if (params.IGNORE_LOCKS) {
+                    cmd << "--ignore-locks"
+                }
 
                 // Needed to detect manual builds
                 wrap([$class: 'BuildUser']) {
@@ -203,15 +206,8 @@ node {
                                 file(credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert', variable: 'RHSM_PULP_CERT'),
                             ]) {
                         withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
-                            if (params.IGNORE_LOCKS) {
-                                sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
-                                sh(script: cmd.join(' '), returnStdout: true)
-                            } else {
-                                lock("github-activity-lock-${params.BUILD_VERSION}") {
-                                    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
-                                    sh(script: cmd.join(' '), returnStdout: true)
-                                }
-                            }
+                            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                            sh(script: cmd.join(' '), returnStdout: true)
                         }
                     }
                 }

--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -69,9 +69,6 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
         stage("Initialize") {
             currentBuild.displayName = "#${currentBuild.number} Scanning version ${params.VERSION}"
 
-            // this lock ensures we are not scanning during an active build
-            activityLockName = "github-activity-lock-${params.VERSION}"
-
             if (params.DRY_RUN) {
                 currentBuild.displayName += "[DRY_RUN]"
             }
@@ -101,46 +98,44 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                     withCredentials([string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'), string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')]) {
                         // There is a vanishingly small race condition here, but it is not dangerous;
                         // it can only lead to undesired delays (i.e. waiting to scan while a build is ongoing).
-                        lock(activityLockName) {
-                            wrap([$class: 'BuildUser']) {
-                                builderEmail = env.BUILD_USER_EMAIL
-                            }
+                        wrap([$class: 'BuildUser']) {
+                            builderEmail = env.BUILD_USER_EMAIL
+                        }
 
-                            withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
-                                try {
-                                    echo "Will run ${cmd}"
-                                    sh(script: cmd.join(' '), returnStdout: true)
+                        withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
+                            try {
+                                echo "Will run ${cmd}"
+                                sh(script: cmd.join(' '), returnStdout: true)
 
-                                    // success email only if requested for this build
-                                    if (params.MAIL_LIST_SUCCESS.trim()) {
-                                        commonlib.email(
-                                            to: "${params.MAIL_LIST_SUCCESS}",
-                                            from: "aos-art-automation@redhat.com",
-                                            replyTo: "aos-team-art@redhat.com",
-                                            subject: "Success scanning OCP version: ${params.VERSION}",
-                                            body: "Success scanning OCP:\n${env.BUILD_URL}"
-                                        )
-                                    }
-
-                                } catch (err) {
-                                    echo "Error running ${params.VERSION} scan:\n${err}"
+                                // success email only if requested for this build
+                                if (params.MAIL_LIST_SUCCESS.trim()) {
                                     commonlib.email(
-                                        to: "${params.MAIL_LIST_FAILURE}",
+                                        to: "${params.MAIL_LIST_SUCCESS}",
                                         from: "aos-art-automation@redhat.com",
                                         replyTo: "aos-team-art@redhat.com",
-                                        subject: "Unexpected error during OCP scan!",
-                                        body: "Encountered an unexpected error while running OCP scan: ${err}"
+                                        subject: "Success scanning OCP version: ${params.VERSION}",
+                                        body: "Success scanning OCP:\n${env.BUILD_URL}"
                                     )
-                                    throw err
-
-                                } finally {
-                                    sh "mv ${doozer_working}/debug.log ${doozer_working}/debug-${params.VERSION}.log"
-                                    sh "bzip2 ${doozer_working}/debug-${params.VERSION}.log"
-                                    commonlib.safeArchiveArtifacts(["${doozer_working}/*.bz2"])
-                                    buildlib.cleanWorkspace()
                                 }
-                            } // withEnv
-                        } // lock
+
+                            } catch (err) {
+                                echo "Error running ${params.VERSION} scan:\n${err}"
+                                commonlib.email(
+                                    to: "${params.MAIL_LIST_FAILURE}",
+                                    from: "aos-art-automation@redhat.com",
+                                    replyTo: "aos-team-art@redhat.com",
+                                    subject: "Unexpected error during OCP scan!",
+                                    body: "Encountered an unexpected error while running OCP scan: ${err}"
+                                )
+                                throw err
+
+                            } finally {
+                                sh "mv ${doozer_working}/debug.log ${doozer_working}/debug-${params.VERSION}.log"
+                                sh "bzip2 ${doozer_working}/debug-${params.VERSION}.log"
+                                commonlib.safeArchiveArtifacts(["${doozer_working}/*.bz2"])
+                                buildlib.cleanWorkspace()
+                            }
+                        } // withEnv
                     } // withCredentials
                 } // withAppCiAsArtPublish
             } // sshagent

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -104,6 +104,10 @@ node {
                 cmd << "--component"
                 cmd << params.DISTGIT_KEY
             }
+            if (params.IGNORE_LOCKS) {
+                cmd << "--ignore-locks"
+            }
+
             sshagent(["openshift-bot"]) {
                 withCredentials([
                     string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN'),
@@ -113,9 +117,6 @@ node {
                     file(credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert', variable: 'RHSM_PULP_CERT'),
                 ]) {
                     echo "Will run ${cmd}"
-                    if (!params.IGNORE_LOCKS) {
-                        lock("github-activity-lock-${params.BUILD_VERSION}")
-                    }
                     withEnv([
                         "BUILD_USER_EMAIL=${builderEmail?: ''}",
                         "BUILD_URL=${BUILD_URL}",

--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -33,6 +33,12 @@ LOCK_POLICY = {
         'retry_delay_min': 0.1,
         'lock_timeout': 60 * 60 * 6,  # 6 hours
     },
+    # ocp4: give up after 1 hour
+    'ocp4': {
+        'retry_count': 36000 * 1,
+        'retry_delay_min': 0.1,
+        'lock_timeout': 60 * 60 * 6,  # 12 hours
+    },
     # mass rebuild: give up after 8 hours
     'mass_rebuild': {
         'retry_count': 36000 * 8,

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -427,7 +427,7 @@ class Ocp4Pipeline:
             return f' [{kind}s except {desc}]'
         return f' [{desc} {plurality}]'
 
-    async def _build_rpms(self):
+    async def _rebase_and_build_rpms(self):
         if not self.build_plan.build_rpms:
             self.runtime.logger.info('Not building RPMs.')
             return
@@ -543,7 +543,7 @@ class Ocp4Pipeline:
             # will find consistent RPMs.
             jenkins.start_rhcos(build_version=self.version.stream, new_build=False, blocking=False)
 
-    async def _update_distgit(self):
+    async def _rebase_images(self):
         if not self.build_plan.build_images:
             self.runtime.logger.info('Not rebasing images')
             return
@@ -820,12 +820,12 @@ class Ocp4Pipeline:
             self.runtime.logger.info('Building only where source has changed.')
             await self._plan_builds()
 
-        await self._build_rpms()
+        await self._rebase_and_build_rpms()
         if not self.skip_plashets:
             await self._build_compose()
         else:
             self.runtime.logger.warning('Skipping plashets creation as SKIP_PLASHETS was set to True')
-        await self._update_distgit()
+        await self._rebase_images()
         await self._build_images()
         await self._sync_images()
         await self._mirror_rpms()

--- a/pyartcd/tests/pipelines/test_check_bugs.py
+++ b/pyartcd/tests/pipelines/test_check_bugs.py
@@ -24,34 +24,6 @@ class TestCheckBugsPipeline(unittest.IsolatedAsyncioTestCase):
         runtime = MagicMock()
         CheckBugsPipeline(runtime, '#valid-channel-name', [])
 
-    @unittest.skip("This test is broken due to production data change")
-    @patch("pyartcd.pipelines.check_bugs.CheckBugsPipeline.initialize_slack_client", return_value=None)
-    @patch("pyartcd.pipelines.check_bugs.CheckBugsPipeline._slack_report", return_value=None)
-    def test_check_applicable_versions(self, *args):
-        runtime = AsyncMock()
-        runtime.logger = LOGGER
-
-        versions = [
-            '3.11',
-            '4.6',
-            '4.7',
-            '4.8',
-            '4.9',
-            '4.10'
-        ]
-        versions.sort()
-
-        # All OCP versions defined above are applicable
-        pipeline = CheckBugsPipeline(runtime, '#test', versions, [])
-        asyncio.run(pipeline._check_applicable_versions())
-        pipeline.applicable_versions.sort()
-        self.assertEqual(versions, pipeline.applicable_versions)
-
-        # Add 4.11, currently (Mar 30, 2022) not in GA
-        pipeline.versions.append('4.11')
-        asyncio.run(pipeline._check_applicable_versions())
-        self.assertNotIn('4.11', pipeline.applicable_versions)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -496,7 +496,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
 
         # no RPMs
         self.assertFalse(self.ocp4.build_plan.build_rpms)
-        await self.ocp4._build_rpms()
+        await self.ocp4._rebase_and_build_rpms()
         cmd_assert_mock.assert_not_awaited()
 
         # Include RPMs
@@ -504,7 +504,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
         self.ocp4.build_plan.build_rpms = True
         self.ocp4.build_plan.rpms_included = ['rpm1']
         self.ocp4.build_plan.rpms_excluded = []
-        await self.ocp4._build_rpms()
+        await self.ocp4._rebase_and_build_rpms()
         cmd_assert_mock.assert_awaited_once_with(
             [
                 'doozer', '--assembly=stream', '--working-dir=doozer_working',
@@ -519,7 +519,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
         self.ocp4.build_plan.build_rpms = True
         self.ocp4.build_plan.rpms_included = []
         self.ocp4.build_plan.rpms_excluded = ['rpm1']
-        await self.ocp4._build_rpms()
+        await self.ocp4._rebase_and_build_rpms()
         cmd_assert_mock.assert_awaited_once_with(
             [
                 'doozer', '--assembly=stream', '--working-dir=doozer_working',
@@ -817,7 +817,7 @@ class TestUpdateDistgit(unittest.IsolatedAsyncioTestCase):
 
         # No images to build
         pipeline.build_plan.build_images = False
-        await pipeline._update_distgit()
+        await pipeline._rebase_images()
         cmd_assert_mock.assert_not_awaited()
         bz_info_missing_mock.assert_not_called()
         reconciliations_mock.assert_not_called()
@@ -828,7 +828,7 @@ class TestUpdateDistgit(unittest.IsolatedAsyncioTestCase):
         bz_info_missing_mock.reset_mock()
         reconciliations_mock.reset_mock()
         pipeline.build_plan.build_images = True
-        await pipeline._update_distgit()
+        await pipeline._rebase_images()
         cmd_assert_mock.assert_awaited_once_with(
             [
                 'doozer', '--assembly=stream', '--working-dir=doozer_working',
@@ -847,7 +847,7 @@ class TestUpdateDistgit(unittest.IsolatedAsyncioTestCase):
         reconciliations_mock.reset_mock()
         pipeline.build_plan.build_images = True
         pipeline.runtime.dry_run = True
-        await pipeline._update_distgit()
+        await pipeline._rebase_images()
         cmd_assert_mock.assert_not_awaited()
         bz_info_missing_mock.assert_not_called()
         reconciliations_mock.assert_not_called()


### PR DESCRIPTION
https://github.com/openshift-eng/aos-cd-jobs/commit/d0604a6b210954e81357ebea9145fa1d994cea9b contains the real change. 

What we currently call `github-activity-lock` is currently shared among `rebuild`, `ocp4` and `ocp4-scan` pipelines. What this PR does is simply move the lock from Jenkins to Redis, and from Groovy into pyartcd.

There's no change in locking logic: once we're ready, we can narrow down the lock scope, wrapping for example only distgit operations.