### PR TITLE
Remove github-activity-lock when finished

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -910,3 +910,6 @@ async def ocp4(runtime: Runtime, version: str, assembly: str, data_path: str, da
         except LockError as e:
             runtime.logger.error('Failed acquiring lock %s: %s', lock_name, e)
             raise
+
+        finally:
+            await lock_manager.destroy()


### PR DESCRIPTION
Locks are currently not being destroyed on time, see https://redis-ui-redis.apps.artc2023.pc3z.p1.openshiftapps.com/