### PR TITLE
Revert "Provide build-microshift pipeline with KUBECONFIG"

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -112,12 +112,10 @@ node('ocp-artifacts') {
                                  string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                                  string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')]) {
                     echo "Will run ${cmd}"
-                    buildlib.withAppCiAsArtPublish() {
-                        if (params.IGNORE_LOCKS) {
-                            commonlib.shell(script: cmd.join(' '))
-                        } else {
-                            lock("build-microshift-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
-                        }
+                    if (params.IGNORE_LOCKS) {
+                        commonlib.shell(script: cmd.join(' '))
+                    } else {
+                        lock("build-microshift-lock-${params.BUILD_VERSION}") { commonlib.shell(script: cmd.join(' ')) }
                     }
                 }
             }

--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -66,9 +66,6 @@ class BuildMicroShiftPipeline:
             self._elliott_env_vars["ELLIOTT_DATA_PATH"] = ocp_build_data_url
 
     async def run(self):
-        # Make sure our api.ci token is fresh
-        await oc.registry_login(self.runtime)
-
         slack_client = None
         assembly_type = AssemblyTypes.STREAM
         major, minor = util.isolate_major_minor_in_group(self.group)


### PR DESCRIPTION
Reverts openshift-eng/aos-cd-jobs#3867

This might relate to a [failure](https://redhat-internal.slack.com/archives/CB95J6R4N/p1691577336242959), suggesting to revert for the time being. 