### PR TITLE
[ART-5863] update elliott to close trackers when OCP ships a kernel

### DIFF
--- a/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
+++ b/pyartcd/pyartcd/pipelines/scan_for_kernel_bugs.py
@@ -53,7 +53,7 @@ class ScanForKernelBugsPipeline:
             "--assembly", "stream",
             "find-bugs:kernel",
             "--clone",
-            "--comment",
+            "--update-tracker",
         ]
         if self.reconcile:
             cmd.append("--reconcile")
@@ -73,7 +73,7 @@ class ScanForKernelBugsPipeline:
             "--assembly", "stream",
             "find-bugs:kernel-clones",
             "--move",
-            "--comment",
+            "--update-tracker",
         ]
         if self.trackers:
             cmd.extend([f"--tracker={tracker}" for tracker in self.trackers])


### PR DESCRIPTION
incorporate https://github.com/openshift-eng/elliott/pull/585

dry run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-stage/job/build%252Fscan-for-kernel-bugs/2/console