### PR TITLE
Prevent long lines getting wrapped in ruamel.yaml

### DIFF
--- a/pyartcd/pyartcd/pipelines/build_microshift.py
+++ b/pyartcd/pyartcd/pipelines/build_microshift.py
@@ -28,7 +28,9 @@ from pyartcd.util import (get_assembly_basis, get_assembly_type,
                           load_releases_config)
 
 yaml = YAML(typ="rt")
+yaml.default_flow_style = False
 yaml.preserve_quotes = True
+yaml.width = 4096
 
 
 class BuildMicroShiftPipeline:

--- a/pyartcd/pyartcd/pipelines/gen_assembly.py
+++ b/pyartcd/pyartcd/pipelines/gen_assembly.py
@@ -15,7 +15,9 @@ from pyartcd.runtime import Runtime
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="rt")
+yaml.default_flow_style = False
 yaml.preserve_quotes = True
+yaml.width = 4096
 
 
 def _merge(a, b):

--- a/pyartcd/pyartcd/pipelines/prepare_release.py
+++ b/pyartcd/pyartcd/pipelines/prepare_release.py
@@ -265,7 +265,9 @@ class PrepareReleasePipeline:
         async with aiofiles.open(path, "r") as f:
             content = await f.read()
         yaml = YAML(typ="safe")
+        yaml.default_flow_style = False
         yaml.preserve_quotes = True
+        yaml.width = 4096
         return yaml.load(content)
 
     async def load_group_config(self) -> Dict:
@@ -275,7 +277,9 @@ class PrepareReleasePipeline:
         async with aiofiles.open(repo / "group.yml", "r") as f:
             content = await f.read()
         yaml = YAML(typ="safe")
+        yaml.default_flow_style = False
         yaml.preserve_quotes = True
+        yaml.width = 4096
         return yaml.load(content)
 
     @classmethod
@@ -393,7 +397,9 @@ class PrepareReleasePipeline:
         else:
             # update releases.yml (if we are operating on a non-stream assembly)
             yaml = YAML(typ="rt")
+            yaml.default_flow_style = False
             yaml.preserve_quotes = True
+            yaml.width = 4096
             async with aiofiles.open(repo / "releases.yml", "r") as f:
                 old = await f.read()
             releases_config = yaml.load(old)

--- a/pyartcd/pyartcd/pipelines/review_cvp.py
+++ b/pyartcd/pyartcd/pipelines/review_cvp.py
@@ -16,6 +16,7 @@ from ruamel.yaml import YAML
 yaml = YAML(typ="rt")
 yaml.default_flow_style = False
 yaml.preserve_quotes = True
+yaml.width = 4096
 
 
 class ReviewCVPPipeline:


### PR DESCRIPTION
A recent change in ruamel.yaml causes long lines getting wrapped. Explicitly setting `yaml.width = 4096` should solve this issue.