### PR TITLE
[ART-5914] Automatically trigger build sync after gen-assembly

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -207,7 +207,8 @@ node('covscan') {
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                     string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                     string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
-                    string(credentialsId: 'redis-port', variable: 'REDIS_PORT')
+                    string(credentialsId: 'redis-port', variable: 'REDIS_PORT'),
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')
                 ]) {
                     sh(script: cmd.join(' '), returnStdout: true)
                 }

--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -85,6 +85,11 @@ node {
                             description: "Take no action, just echo what the job would have done.",
                             defaultValue: false
                         ),
+                        booleanParam(
+                            name: "TRIGGER_BUILD_SYNC",
+                            description: "Automatically trigger build sync against the automatically created PR",
+                            defaultValue: true
+                        ),
                         commonlib.mockParam(),
                     ]
                 ],
@@ -156,9 +161,17 @@ node {
             } else {
                 cmd << "--auto-previous"
             }
+            if (params.TRIGGER_BUILD_SYNC) {
+                cmd << "--auto-trigger-build-sync"
+            }
 
             buildlib.withAppCiAsArtPublish() {
-                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN')]) {
+                withCredentials([
+                    string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')
+                ]) {
                     commonlib.shell(script: cmd.join(' '))
                 }
             }


### PR DESCRIPTION
Automatically trigger build sync after gen-assembly and comment the link of the build sync URL on the auto generated PR. 

Changes:
- gen-assembly: new TRIGGER_BUILD_SYNC option which will trigger build-sync with the auto-generated PR
- build-sync: if triggered with assembly (not with stream) and DOOZER_DATA_GIT_REF is not empty, it will try to look for the PR and comment before and after the job. If failed, it will report that as well. It will work for build-sync directly triggered by humans as well.

Continuation of https://github.com/openshift-eng/aos-cd-jobs/pull/3605

- Tested gen-assembly ([job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/origin-gen-assembly/5)), automatically triggered build sync [job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/35778)
- Test build-sync [run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build-sync/7/) which commented on [PR](https://github.com/openshift-eng/ocp-build-data/pull/3387)
- Test [build-sync](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build-sync/8/) commented on the [PR](https://github.com/openshift-eng/ocp-build-data/pull/3389) that I created from my own branch