### PR TITLE
[ocp4] Have block_until_building=False for sync-for-ci

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -532,13 +532,15 @@ class Ocp4Pipeline:
         if self.assembly == 'stream':
             # Since plashets may have been rebuilt, fire off sync for CI. This will transfer RPMs out to
             # mirror.openshift.com/enterprise so that they may be consumed through CI rpm mirrors.
-            jenkins.start_sync_for_ci(version=self.version.stream, blocking=False)
+            # Set block_until_building=False since it can take a very long time for the job to start
+            # it is enough for it to be queued
+            jenkins.start_sync_for_ci(version=self.version.stream, block_until_building=False)
 
             # Also trigger rhcos builds for the release in order to absorb any changes from plashets or RHEL which may
             # have triggered our rebuild. If there are no changes to the RPMs, the build should exit quickly. If there
             # are changes, the hope is that by the time our images are done building, RHCOS will be ready and build-sync
             # will find consistent RPMs.
-            jenkins.start_rhcos(build_version=self.version.stream, new_build=False, blocking=False)
+            jenkins.start_rhcos(build_version=self.version.stream, new_build=False)
 
     async def _rebase_images(self):
         if not self.build_plan.build_images:

--- a/pyartcd/pyartcd/pipelines/ocp4_scan.py
+++ b/pyartcd/pyartcd/pipelines/ocp4_scan.py
@@ -55,7 +55,6 @@ class Ocp4ScanPipeline:
             jenkins.start_ocp4(
                 build_version=self.version,
                 assembly='stream',
-                blocking=False,
                 rpm_list=self.changes.get('rpms', []),
                 image_list=self.changes.get('images', []),
             )
@@ -70,7 +69,7 @@ class Ocp4ScanPipeline:
             # Inconsistency probably means partial failure and we would like to retry.
             # but don't kick off more if already in progress.
             self.logger.info('Triggering a %s RHCOS build for consistency', self.version)
-            jenkins.start_rhcos(build_version=self.version, new_build=True, blocking=False)
+            jenkins.start_rhcos(build_version=self.version, new_build=True)
 
         elif self.rhcos_changed:
             self.logger.info('Detected at least one updated RHCOS')
@@ -83,7 +82,6 @@ class Ocp4ScanPipeline:
             jenkins.start_build_sync(
                 build_version=self.version,
                 assembly="stream",
-                blocking=False
             )
 
     async def _get_changes(self):


### PR DESCRIPTION
For https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/scheduled-builds/job/sync-for-ci/ job
we don't want to wait until it starts building because it can take a very long time,
because the job is configured to not run in parallel.

So provide an option to have block_until_building=False
In addition, have other jobs pass in `blocking` kwargs to `start_build` directly
