### PR TITLE
Add jenkins.py unit tests

### DIFF
--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -768,8 +768,9 @@ class TestBuildCompose(unittest.IsolatedAsyncioTestCase):
         self.ocp4.assembly = 'stream'
         await self.ocp4._build_compose()
         mocked_build_plashets.assert_awaited_once()
-        mocked_rhcos.assert_called_once()
-        mocked_sync_for_ci.assert_called_once()
+        mocked_rhcos.assert_called_once_with(build_version='4.13', new_build=False)
+        mocked_sync_for_ci.assert_called_once_with(
+            version='4.13', block_until_building=False)
         self.assertEqual(self.ocp4.rpm_mirror.local_plashet_path, '')
         self.assertEqual(self.ocp4.rpm_mirror.plashet_dir_name, '')
 

--- a/pyartcd/tests/test_jenkins.py
+++ b/pyartcd/tests/test_jenkins.py
@@ -1,0 +1,67 @@
+import unittest
+import os
+from mock import mock
+from pyartcd import jenkins
+
+
+class TestJenkinsStartBuild(unittest.TestCase):
+    @mock.patch("pyartcd.jenkins.init_jenkins")
+    @mock.patch("pyartcd.jenkins.jenkins_client")
+    def test_start_build_dont_block(self, mock_client, mock_init_jenkins):
+        job_name = "foo"
+        params = {"param1": "value1", "param2": "value2"}
+        mock_job = mock.MagicMock()
+        mock_client.get_job.return_value = mock_job
+        jenkins.start_build(job_name, params, block_until_building=False)
+
+        mock_init_jenkins.assert_called_once()
+        mock_client.get_job.assert_called_once_with(job_name)
+        mock_job.invoke.assert_called_once_with(build_params=params)
+
+    @mock.patch("pyartcd.jenkins.Build")
+    @mock.patch("pyartcd.jenkins.init_jenkins")
+    @mock.patch("pyartcd.jenkins.jenkins_client")
+    def test_start_build_block_until_building(self, mock_client, mock_init_jenkins, mock_build):
+        job_name = "foo"
+        params = {"param1": "value1", "param2": "value2"}
+        delay = 10
+        mock_client.get_job.return_value = mock_job = mock.MagicMock()
+        mock_job.invoke.return_value = mock_queue_item = mock.MagicMock()
+        mock_queue_item.poll.return_value = {'executable': {'number': 1}, 'task': {'url': 'folder/foo/'}}
+        triggered_url = 'folder/foo/1'
+        os.environ['BUILD_URL'] = 'folder/bar/1'
+        os.environ['JOB_NAME'] = 'bar'
+
+        result = jenkins.start_build(job_name, params, block_until_building=True, watch_building_delay=delay)
+        self.assertEqual(result, None)
+
+        mock_init_jenkins.assert_called_once()
+        mock_client.get_job.assert_called_once_with(job_name)
+        mock_job.invoke.assert_called_once_with(build_params=params)
+        mock_queue_item.poll.assert_called_once()
+        mock_build.assert_called_once_with(url=triggered_url, buildno=1, job=mock_job)
+
+    @mock.patch("pyartcd.jenkins.Build")
+    @mock.patch("pyartcd.jenkins.init_jenkins")
+    @mock.patch("pyartcd.jenkins.jenkins_client")
+    def test_start_build_block_until_complete(self, mock_client, mock_init_jenkins, mock_build):
+        job_name = "foo"
+        params = {"param1": "value1", "param2": "value2"}
+        delay = 10
+        mock_client.get_job.return_value = mock_job = mock.MagicMock()
+        mock_job.invoke.return_value = mock_queue_item = mock.MagicMock()
+        mock_queue_item.poll.return_value = {'executable': {'number': 1}, 'task': {'url': 'folder/foo/'}}
+        triggered_url = 'folder/foo/1'
+        os.environ['BUILD_URL'] = 'folder/bar/1'
+        os.environ['JOB_NAME'] = 'bar'
+        mock_build.return_value.poll.return_value = {'result': 'SUCCESS'}
+
+        result = jenkins.start_build(job_name, params, block_until_building=True,
+                                     block_until_complete=True, watch_building_delay=delay)
+        self.assertEqual(result, 'SUCCESS')
+
+        mock_init_jenkins.assert_called_once()
+        mock_client.get_job.assert_called_once_with(job_name)
+        mock_job.invoke.assert_called_once_with(build_params=params)
+        mock_queue_item.poll.assert_called_once()
+        mock_build.assert_called_once_with(url=triggered_url, buildno=1, job=mock_job)


### PR DESCRIPTION
Follow up to https://github.com/openshift-eng/aos-cd-jobs/pull/3893 and https://github.com/openshift-eng/aos-cd-jobs/pull/3894

`jenkins.start_build` unit tests are missing so any change is a risky change

Summary
- Extract `set_build_description` into it's own function
- Refactor to have more precise var names
- Add unit tests for `jenkins.start_build`