### PR TITLE
[ART-3476] fix parameter error in signing job

### DIFF
--- a/jobs/build/coreos-installer_sync/Jenkinsfile
+++ b/jobs/build/coreos-installer_sync/Jenkinsfile
@@ -117,7 +117,7 @@ node {
             key_name: "redhatrelease2",
             arch: "x86_64",
             digest: "",
-            client_type: "",
+            client_type: "ocp",
             product: "coreos-installer",
         )
 


### PR DESCRIPTION
fix the error in https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcoreos-installer_sync/15/console to set the parameter default value to ocp, although the coreos-installer signing workflow don't use this value