### PR TITLE
WIP Extend lock if needed

### DIFF
--- a/pyartcd/pyartcd/locks.py
+++ b/pyartcd/pyartcd/locks.py
@@ -25,7 +25,7 @@ LOCK_POLICY = {
     Lock.OLM_BUNDLE: {
         'retry_count': 36000,
         'retry_delay_min': 0.1,
-        'lock_timeout': 60 * 60 * 2,  # 2 hours
+        'lock_timeout': 60 * 30 # 30 minutes
     },
     # mirror RPMs: give up after 1 hour
     Lock.MIRRORING_RPMS: {

--- a/pyartcd/pyartcd/pipelines/olm_bundle.py
+++ b/pyartcd/pyartcd/pipelines/olm_bundle.py
@@ -2,7 +2,6 @@ import os
 
 import click
 from aioredlock import LockError
-import atexit
 
 from pyartcd import constants, exectools
 from pyartcd.cli import cli, pass_runtime, click_coroutine


### PR DESCRIPTION
Right now we acquire locks for what we think is the duration of the job (example 8 hours for mass rebuild lock)
In case if the job is aborted, a lock isn't released until the timeout is reached.

Instead we can acquire a lock for a short duration, and keep extending it if we are still processing