### PR TITLE
[ART-7544] Add sast-scanning job

### DIFF
--- a/jobs/build/scan-osh/Jenkinsfile
+++ b/jobs/build/scan-osh/Jenkinsfile
@@ -1,0 +1,76 @@
+node('ocp-artifacts') {
+    wrap([$class: "BuildUser"]) {
+        // gomod created files have filemode 444. It will lead to a permission denied error in the next build.
+        sh "chmod u+w -R ."
+        checkout scm
+        def buildlib = load("pipeline-scripts/buildlib.groovy")
+        def commonlib = buildlib.commonlib
+
+        commonlib.describeJob("scan-osh", """
+            <h2>Kick off SAST scans for builds</h2>
+        """)
+
+        properties(
+            [
+                disableResume(),
+                buildDiscarder(
+                    logRotator(
+                        artifactDaysToKeepStr: "30",
+                        artifactNumToKeepStr: "",
+                        daysToKeepStr: "30",
+                        numToKeepStr: "")),
+                [
+                    $class: "ParametersDefinitionProperty",
+                    parameterDefinitions: [
+                        string(
+                            name: "BUILD_NVRS",
+                            description: "The list of builds for which we need to kick off the scan",
+                            defaultValue: "",
+                            trim: true
+                        ),
+                        string(
+                            name: "EMAIL",
+                            description: "Additional email to which the results of the scan should be sent out to",
+                            defaultValue: "",
+                            trim: true
+                        ),
+                        commonlib.mockParam(),
+                    ]
+                ],
+            ]
+        )
+
+        commonlib.checkMock()
+
+        stage("initialize") {
+                if (!params.BUILD_NVRS) {
+                    error("BUILD_NVRS is required")
+                }
+        }
+
+        stage("kick-off-scan") {
+            buildlib.cleanWorkdir("./artcd_working")
+            sh "mkdir -p ./artcd_working"
+
+            def builds = BUILD_NVRS.split(',')
+
+            for (String build : builds) {
+                def cmd = [
+                    "osh-cli",
+                    "mock-build",
+                    "--config=cspodman",
+                    "--brew-build",
+                    "${build}",
+                    "--nowait"
+                ]
+
+                if (params.EMAIL) {
+                    cmd << "--email-to ${EMAIL}"
+                }
+
+                echo "Will run ${cmd}"
+                commonlib.shell(script: cmd.join(' '))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since `osh-cli` only supported on rhel8, created this job on ocp-artifacts. Follow solution outlined in this [ticket](https://issues.redhat.com/browse/OSH-190?focusedId=22851929&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22851929).

Run with one image [test](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/sast-scanning/18).
Run with two images [test](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/sast-scanning/19)