### PR TITLE
[ART-7544] Kick off SAST scan for successful builds

### DIFF
--- a/pyartcd/pyartcd/jenkins.py
+++ b/pyartcd/pyartcd/jenkins.py
@@ -28,6 +28,7 @@ class Jobs(Enum):
     OLM_BUNDLE = 'aos-cd-builds/build%2Folm_bundle'
     SYNC_FOR_CI = 'scheduled-builds/sync-for-ci'
     MICROSHIFT_SYNC = 'aos-cd-builds/build%2Fmicroshift_sync'
+    SCAN_OSH = 'aos-cd-builds/build%2Fscan-osh'
 
 
 def init_jenkins():
@@ -313,3 +314,18 @@ def update_description(description: str, append: bool = True):
         description = build.get_description() + description
 
     set_build_description(build, description)
+
+
+def start_scan_osh(build_nvrs: str, email: Optional[str] = "", **kwargs):
+    params = {
+        'BUILD_NVRS': build_nvrs
+    }
+
+    if email:
+        params['EMAIL'] = email
+
+    return start_build(
+        job_name=Jobs.SCAN_OSH.value,
+        params=params,
+        **kwargs
+    )

--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -677,6 +677,12 @@ class Ocp4Pipeline:
             cmd.extend(['images:streams', 'mirror'])
             await exectools.cmd_assert_async(cmd)
 
+        # Kick off SAST scans for builds that succeeded using the NVR
+        successful_build_nvrs = [build["nvrs"] for build in success_map.values()]
+
+        if successful_build_nvrs:
+            jenkins.start_scan_osh(build_nvrs=",".join(successful_build_nvrs))
+
     async def _sync_images(self):
         if not self.build_plan.build_images:
             self.runtime.logger.info('No built images to sync.')

--- a/pyartcd/tests/pipelines/test_ocp4.py
+++ b/pyartcd/tests/pipelines/test_ocp4.py
@@ -532,6 +532,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
     @patch("shutil.rmtree")
     @patch("builtins.open")
     @patch("pyartcd.jenkins.update_title")
+    @patch("pyartcd.jenkins.start_scan_osh")
     @patch("pyartcd.jenkins.update_description")
     @patch("pyartcd.util.default_release_suffix", return_value="2100123111.p?")
     @patch("pyartcd.exectools.cmd_gather_async", autospec=True, return_value=(0, "rhaos-4.13-rhel-8", ""))
@@ -591,7 +592,7 @@ class TestBuilds(unittest.IsolatedAsyncioTestCase):
 
         # ApiServer rebuilt
         cmd_assert_mock.reset_mock()
-        parse_record_log_mock.return_value = {'build': [{'distgit': 'ose-openshift-apiserver', 'status': '0'}]}
+        parse_record_log_mock.return_value = {'build': [{'distgit': 'ose-openshift-apiserver', 'status': '0', 'nvrs': 'bogus'}]}
         self.ocp4.runtime.dry_run = False
         self.ocp4.build_plan.build_images = True
         self.ocp4.build_plan.images_included = ['image1', 'image2']


### PR DESCRIPTION
Run the `scan-osh` job and pass along the NVRs of the builds that succeeded.

Test run ocp4 [job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/ocp4/2/console). Which triggered [scan-osh](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fscan-osh/4/console)