### PR TITLE
add [TEST] to title for test ocp4 build

### DIFF
--- a/pyartcd/pyartcd/pipelines/ocp4.py
+++ b/pyartcd/pyartcd/pipelines/ocp4.py
@@ -810,6 +810,9 @@ class Ocp4Pipeline:
     async def run(self):
         await self._initialize()
 
+        if self.assembly.lower() == "test":
+            jenkins.update_title(" [TEST]")
+
         if self.build_plan.pin_builds:
             self.runtime.logger.info('Pinned builds (whether source changed or not)')
             self._plan_pinned_builds()


### PR DESCRIPTION
Since `ocp4` can now be used for test builds, having `[TEST]` in title will enable us to easily differentiate between job runs.

Test [run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build%252Focp4/61/)