### PR TITLE
Allow multiple ironic packages versions in plashets

### DIFF
--- a/pyartcd/pyartcd/plashets.py
+++ b/pyartcd/pyartcd/plashets.py
@@ -31,6 +31,14 @@ previous_packages = [
     "python3-openvswitch",
 ]
 
+ironic_previous_packages = [
+    "openstack-ironic",
+    "openstack-ironic-inspector",
+    "openstack-ironic-python-agent",
+    "python-ironic-lib",
+    "python-sushy",
+]
+
 
 def plashet_config_for_major_minor(major, minor):
     return {
@@ -56,7 +64,7 @@ def plashet_config_for_major_minor(major, minor):
             "product_version": f"OSE-IRONIC-{major}.{minor}-RHEL-9",
             "include_embargoed": False,
             "embargoed_tags": [],  # unlikely to exist until we begin using -gating tag
-            "include_previous_packages": [],
+            "include_previous_packages": ironic_previous_packages,
         },
         "rhel-8-server-ose-rpms-embargoed": {
             "slug": "el8-embargoed",


### PR DESCRIPTION
Metal Platform Team needs to pin specific packages for precise tests and updates.
With this PR we introduce a new list of packages specific for ironic containers that are allowed to be present in multiple versions in the plashets.
We'll start covering only the main packages but we may need to expand the list in the future, separating it fromthe main list of packages is the most sensible solution.