### PR TITLE
Fix RHACS s3 target dir

### DIFF
--- a/jobs/build/client_sync/Jenkinsfile
+++ b/jobs/build/client_sync/Jenkinsfile
@@ -131,7 +131,7 @@ node {
 
     stage("Sync to mirror") {
         if (params.LOCATION.startsWith("rcm-guest")) {
-            source_path = params.LOCATION.substring(10)
+            source_path = "${params.LOCATION.substring(10)}/"
             commonlib.shell(
                 script:
                 """


### PR DESCRIPTION
Current job is nesting folders in s3, see [this run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fclient_sync/30/console).

 Test run from hack space removed the extra folder: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/client-sync/29/console