### PR TITLE
ART-7628 Add job to clean up unreleased locks from on Redis

### DIFF
--- a/jobs/maintenance/cleanup-locks/Jenkinsfile
+++ b/jobs/maintenance/cleanup-locks/Jenkinsfile
@@ -1,0 +1,57 @@
+#!/usr/bin/env groovy
+node {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+
+    commonlib.describeJob("cleanup-locks", """
+        ----------
+        Cleanup locks
+        ----------
+        Clean up locks that might stay locked after cancelling jobs by hand.
+
+        Timing: Triggered by jobs on user interruption:
+        - ocp4
+    """)
+
+    properties(
+        [
+            disableResume(),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.mockParam(),
+                    string(
+                        name: "LOCKS",
+                        description: 'Comma/space-separated list of locks to be removed',
+                        trim: true,
+                    )
+                ]
+            ]
+        ]
+    )
+
+    // Check for mock build
+    commonlib.checkMock()
+
+    // Clean up locks
+    stage('cleanup-locks') {
+        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        def cmd = [
+            "artcd",
+            "-v",
+            "--working-dir=./artcd_working",
+            "--config=./config/artcd.toml",
+            "cleanup-locks",
+            "--locks=${commonlib.cleanCommaList(params.LOCKS)}"
+        ]
+
+        withCredentials([
+                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                    string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
+                    string(credentialsId: 'redis-port', variable: 'REDIS_PORT'),
+                ]) {
+            sh(script: cmd.join(' '), returnStdout: true)
+        }
+    }
+}

--- a/pyartcd/pyartcd/__main__.py
+++ b/pyartcd/pyartcd/__main__.py
@@ -4,7 +4,7 @@ from pyartcd.cli import cli
 from pyartcd.pipelines import (
     build_microshift, check_bugs, gen_assembly, prepare_release, promote, rebuild, report_rhcos,
     review_cvp, tarball_sources, build_sync, build_rhcos, ocp4_scan, images_health, operator_sdk_sync,
-    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop
+    olm_bundle, ocp4, scan_for_kernel_bugs, tag_rpms, advisory_drop, cleanup_locks
 )
 
 

--- a/pyartcd/pyartcd/pipelines/cleanup_locks.py
+++ b/pyartcd/pyartcd/pipelines/cleanup_locks.py
@@ -1,0 +1,22 @@
+import click
+
+from pyartcd import redis
+from pyartcd.cli import cli, click_coroutine, pass_runtime
+from pyartcd.runtime import Runtime
+
+
+@cli.command('cleanup-locks')
+@click.option('--locks', required=True, help='Locks to be released on Redis')
+@pass_runtime
+@click_coroutine
+async def cleanup_locks(runtime: Runtime, locks: str):
+    locks_to_release = filter(lambda arg: arg, locks.split(','))
+
+    for lock_name in locks_to_release:
+        runtime.logger.warning('Deleting lock %s', lock_name)
+        res = await redis.delete_key(lock_name)
+
+        if res:
+            runtime.logger.info('Lock %s deleted', lock_name)
+        else:
+            runtime.logger.warning('Lock %s could not be found', lock_name)

--- a/pyartcd/pyartcd/redis.py
+++ b/pyartcd/pyartcd/redis.py
@@ -75,10 +75,11 @@ async def get_keys(conn: aioredis.commands.Redis, pattern: str):
 
 
 @handle_connection
-async def delete_key(conn: aioredis.commands.Redis, key: str):
+async def delete_key(conn: aioredis.commands.Redis, key: str) -> int:
     """
     Deletes given key from Redis DB
+    Returns: 1 if successful, 0 otherwise
     """
 
     logger.debug('Deleting key %s', key)
-    await conn.delete(key)
+    return await conn.delete(key)


### PR DESCRIPTION
Catching the Jenkins user interruption in pyartcd is not deterministic: SIGTERM will wait for threads to complete gracefully, but a SIGKILL will be sent if they don't within a predefined timeout. In this case, no handling procedure will be executed, leaving resources uncleaned.

The proposed solution is to handle the interruption within the Jenkinsfile itself. Then, a new job is called which will be responsible for unlocking all locks left unattended by the interrupted job. `ocp4` will fill the `LOCKS` param according to what locks might have been created. The job will unlock them, if they exist.