### PR TITLE
ART-7628 Store Jenkins job ID as lock value

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -152,6 +152,8 @@ node {
         currentBuild.description = ""
     }
 
+    def job_id = "ocp4-${currentBuild.number}"
+
     try {
 
         sshagent(["openshift-bot"]) {
@@ -194,8 +196,8 @@ node {
 
                 // Needed to detect manual builds
                 wrap([$class: 'BuildUser']) {
-                        builderEmail = env.BUILD_USER_EMAIL
-                    }
+                    builderEmail = env.BUILD_USER_EMAIL
+                }
 
                 buildlib.withAppCiAsArtPublish() {
                     withCredentials([
@@ -213,7 +215,7 @@ node {
                                 file(credentialsId: 'art-jenkins-ldap-serviceaccount-private-key', variable: 'RHSM_PULP_KEY'),
                                 file(credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert', variable: 'RHSM_PULP_CERT'),
                             ]) {
-                        withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
+                        withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", "JOB_ID=${job_id}", 'DOOZER_DB_NAME=art_dash']) {
                             sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
                             sh(script: cmd.join(' '), returnStdout: true)
                         }
@@ -248,7 +250,10 @@ node {
             locksToBeRemoved << "mass-rebuild-serializer"
         }
 
-        build job: '../maintenance/maintenance%2Fcleanup-locks', parameters: [string(name: 'LOCKS', value: locksToBeRemoved.join(','))], propagate: false
+        build job: 'maintenance/maintenance%2Fcleanup-locks',
+              parameters: [string(name: 'LOCKS', value: locksToBeRemoved.join(',')),
+                           string(name: 'JOB_ID', value: job_id)],
+              propagate: false
 
     } catch (err) {
         if (params.MAIL_LIST_FAILURE.trim()) {

--- a/jobs/maintenance/cleanup-locks/Jenkinsfile
+++ b/jobs/maintenance/cleanup-locks/Jenkinsfile
@@ -25,6 +25,11 @@ node {
                         name: "LOCKS",
                         description: 'Comma/space-separated list of locks to be removed',
                         trim: true,
+                    ),
+                    string(
+                        name: "JOB_ID",
+                        description: 'Unique identifier of the job that supposedly created the locks to be removed',
+                        trim: true,
                     )
                 ]
             ]
@@ -43,7 +48,8 @@ node {
             "--working-dir=./artcd_working",
             "--config=./config/artcd.toml",
             "cleanup-locks",
-            "--locks=${commonlib.cleanCommaList(params.LOCKS)}"
+            "--locks=${commonlib.cleanCommaList(params.LOCKS)}",
+            "--job-id=${params.JOB_ID}"
         ]
 
         withCredentials([


### PR DESCRIPTION
By setting the lock identifier to the ID of the job that created it, we can prevent cases where aborted jobs cancel a lock that was created by a previous (and still running) job.

Tested with:
- nominal scenario: [ocp4](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/234/console) was aborted, [cleanup-locks](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/cleanup-locks/15/console) was triggered and deleted `build-lock-4.8`
- [ocp4-235](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/235/console) created `build-lock-4.8` and was running; [ocp4-236](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/236/console) was started, got blocked on the lock, then got canceled; [cleanup-locks](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/cleanup-locks/16/console) was triggered, but `build-lock-4.8` was not deleted as it belonged to the previous ocp4 run