### PR TITLE
ART-7628 Run lock cleanup procedure on a schedule

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -233,23 +233,6 @@ node {
                 }
             }
         }
-
-    } catch (FlowInterruptedException interruptEx) {
-        // In case of manual interruption, we need to clean up locks
-        // that have possibly been created by the job run, including mass-rebuild-serializer
-        echo "***** Interrupted by user; will clean up"
-        locksToBeRemoved = [
-            "compose-lock-${params.BUILD_VERSION}",
-            "build-lock-${params.BUILD_VERSION}",
-            "mirroring-rpms-${params.BUILD_VERSION}"
-        ]
-
-        if (isMassRebuild()) {
-            locksToBeRemoved << "mass-rebuild-serializer"
-        }
-
-        build job: '../maintenance/maintenance%2Fcleanup-locks', parameters: [string(name: 'LOCKS', value: locksToBeRemoved.join(','))], propagate: false
-
     } catch (err) {
         if (params.MAIL_LIST_FAILURE.trim()) {
             commonlib.email(

--- a/jobs/maintenance/cleanup-locks/Jenkinsfile
+++ b/jobs/maintenance/cleanup-locks/Jenkinsfile
@@ -21,11 +21,7 @@ node {
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     commonlib.mockParam(),
-                    string(
-                        name: "LOCKS",
-                        description: 'Comma/space-separated list of locks to be removed',
-                        trim: true,
-                    )
+                    commonlib.artToolsParam()
                 ]
             ]
         ]
@@ -43,13 +39,14 @@ node {
             "--working-dir=./artcd_working",
             "--config=./config/artcd.toml",
             "cleanup-locks",
-            "--locks=${commonlib.cleanCommaList(params.LOCKS)}"
         ]
 
         withCredentials([
                     string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                     string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
                     string(credentialsId: 'redis-port', variable: 'REDIS_PORT'),
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')
                 ]) {
             sh(script: cmd.join(' '), returnStdout: true)
         }

--- a/scheduled-jobs/maintenance/cleanup-locks/Jenkinsfile
+++ b/scheduled-jobs/maintenance/cleanup-locks/Jenkinsfile
@@ -1,0 +1,14 @@
+properties( [
+    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+    disableConcurrentBuilds(),
+    disableResume(),
+] )
+
+node() {
+    checkout scm
+
+    build(
+        job: '../maintenance/maintenance%2Fcleanup-locks',
+        propagate: false,
+    )
+}


### PR DESCRIPTION
Must go with https://github.com/openshift-eng/art-tools/pull/38

[Test build](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/cleanup-locks/39/console): 
- `build-lock-4.9` was created by hand to point at a running build; the cleanup skipped it with this message:
   ```Build job/aos-cd-builds/job/build%252Focp4/46895/ is still running: won't delete lock build-lock-4.9```
- `build-lock-4.10` was created by [job/hack/job/dpaolell/job/ocp4/238](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/238/) that had been aborted; the lock is correctly deleted (`Deleting lock build-lock-4.10`)
- for locks with random IDs (that's how we currently create them), no build can be associated; these get skipped because
  ```
  ERROR Could not fetch data for build 7dce1a20-e79c-4257-b15c-78727a1fff04
  WARNING Could not get build from lock build-lock-4.13: skipping
  ```