### PR TITLE
ART-7628 Provide promote with BUILD_URL env var

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -188,9 +188,11 @@ node {
                              string(credentialsId: 'redis-host', variable: 'REDIS_HOST'),
                              string(credentialsId: 'redis-port', variable: 'REDIS_PORT'),
                             ]) {
-                def out = sh(script: cmd.join(' '), returnStdout: true).trim()
-                echo "artcd returns:\n$out"
-                release_info = readJSON(text: out)
+                withEnv("BUILD_URL=${BUILD_URL}") {
+                    def out = sh(script: cmd.join(' '), returnStdout: true).trim()
+                    echo "artcd returns:\n$out"
+                    release_info = readJSON(text: out)
+                }
             }
         }
     }


### PR DESCRIPTION
`BUILD_URL` env var is needed by `pyartcd` to set the lock value equal to the Jenkins build path