### PR TITLE
Cleanup images list

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -183,7 +183,7 @@ node {
                     "--build-rpms=${params.BUILD_RPMS}",
                     "--rpm-list=${params.RPM_LIST}",
                     "--build-images=${params.BUILD_IMAGES}",
-                    "--image-list=${params.IMAGE_LIST}"
+                    "--image-list=${commonlib.cleanCommaList(params.IMAGE_LIST)}"
                 ]
                 if (params.SKIP_PLASHETS) {
                     cmd << "--skip-plashets"


### PR DESCRIPTION
Fixes this error:
```
artcd -v --working-dir=./artcd_working --config=./config/artcd.toml ocp4 --version=4.15 --assembly=test --data-path=https://github.com/locriandev/ocp-build-data --pin-builds --build-rpms=none --rpm-list= --build-images=only --image-list=openshift-enterprise-base-rhel9, ose-agent-installer-utils --ignore-locks
Usage: artcd ocp4 [OPTIONS]
Try 'artcd ocp4 -h' for help.

Error: Got unexpected extra argument (ose-agent-installer-utils)
```