### PR TITLE
Pass DRY_RUN to artcd

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -166,6 +166,11 @@ node {
                     "-v",
                     "--working-dir=./artcd_working",
                     "--config=./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
                     "ocp4",
                     "--version=${params.BUILD_VERSION}",
                     "--assembly=${params.ASSEMBLY}",


### PR DESCRIPTION
`DRY_RUN` parameter is received in the jenkins job and pyatrcd. Passing from the former to latter.

_Ready to merge. Requesting lgtm and approve_