### PR TITLE
Scheduled job to run scan-osh for each version

### DIFF
--- a/scheduled-jobs/build/scan-osh/Jenkinsfile
+++ b/scheduled-jobs/build/scan-osh/Jenkinsfile
@@ -1,0 +1,35 @@
+node {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+    slacklib = commonlib.slacklib
+
+    properties( [
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+        disableConcurrentBuilds(),
+        disableResume(),
+    ] )
+
+    def versionJobs = [:]
+    for ( version in commonlib.ocp4Versions ) {
+        def cv = "${version}" // make sure we use a locally scoped variable
+
+        // Trigger SAST scan for ${version}
+        versionJobs["scan-v${version}"] = {
+            try {
+                timeout(activity: true, time: 30, unit: 'MINUTES') {
+                    build job: '../aos-cd-builds/build%2Fscan-osh',
+                    parameters: [
+                        string(name: 'BUILD_VERSION', value: "${cv}"),
+                        boolean(name: 'CHECK_TRIGGERED', value: true),
+                    ],
+                    propagate: false
+                }
+            } catch (te) {
+                slacklib.to(cv).failure("Error running scan-osh", te)
+            }
+        }
+    }
+
+    parallel versionJobs
+}


### PR DESCRIPTION
Running with default option to trigger scans progressively and storing value in Redis. Adding `CHECK_TRIGGERD` flag so that we do not trigger scans for ones that we already built. Since for now we are triggering there for those particular NVRs as well

_Requesting lgtm only. Want to check before merge._