### PR TITLE
[ART-4932] bump to refactored art-tools

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -160,9 +160,9 @@ def setup_venv(use_python38=false) {
         commonlib.shell(script: "rm -rf art-tools;  git clone https://github.com/${where[0]}/art-tools.git; cd art-tools; git checkout ${where[1]}")
     }
 
-    commonlib.shell(script: "pip install -e art-tools/elliott/ -e art-tools/doozer/ -e art-tools/pyartcd/")
+    commonlib.shell(script: "cd art-tools && ./install.sh")
     out = sh(
-        script: 'pip list | grep "doozer\\|elliott"',
+        script: 'pip list | grep "doozer\\|elliott\\|pyartcd"',
         returnStdout: true
     )
     echo "Installed pyartcd:"

--- a/tekton-pipelines/images/artcd/Containerfile
+++ b/tekton-pipelines/images/artcd/Containerfile
@@ -14,7 +14,7 @@ RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.opensh
 COPY pyartcd pyartcd
 COPY art-tools art-tools
 RUN python3 -m pip wheel --wheel-dir /usr/local/src/wheels \
-  ./art-tools/elliott ./art-tools/doozer ./pyartcd
+  ./art-tools/elliott ./art-tools/doozer ./art-tools/pyartcd
 
 FROM registry.access.redhat.com/ubi9/ubi:9.2
 LABEL name="openshift-art/art-cd" \


### PR DESCRIPTION
incorporates https://github.com/openshift-eng/art-tools/pull/86 and related changes to consume it.

running test jobs at https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/lmeyer/job/lmeyer-stage/