### PR TITLE
Clear aws cache for mirror_path as well

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -179,6 +179,10 @@ node {
                                 commonlib.shell(script:"""
                                 aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${latest_path}/*"
                                 """)
+
+                                commonlib.shell(script:"""
+                                aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${mirror_path}/*"
+                                """)
                             }
                         }
                     }


### PR DESCRIPTION
Clear aws cache for mirror_path in case of microshift force rebuild for a particular version, as `rpm_list` was not getting updated.

Ref [slack](https://redhat-internal.slack.com/archives/CB95J6R4N/p1697138145592669?thread_ts=1697122268.631459&cid=CB95J6R4N)