### PR TITLE
fix compress log error in golang builder job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -1,3 +1,8 @@
+def compressBrewLogs() {
+    echo "Compressing brew logs.."
+    commonlib.shell(script: "./find-and-compress-brew-logs.sh")
+}
+
 node {
     cleanWs(cleanWhenFailure: false)
     checkout scm
@@ -115,7 +120,7 @@ pipeline {
     post {
         always {
             script {
-                commonlib.compressBrewLogs()
+                compressBrewLogs()
                 commonlib.safeArchiveArtifacts([
                     "doozer_working/*.log",
                     "doozer_working/*.yaml",

--- a/jobs/build/golang-builder/find-and-compress-brew-logs.sh
+++ b/jobs/build/golang-builder/find-and-compress-brew-logs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+BREWLOGS=`find artcd_working -name brew-logs -type d`
+
+
+if [ -s "${BREWLOGS}" ]; then
+    echo "Brew logs (${BREWLOGS}) currently taking space:"
+    du -sh $BREWLOGS
+else
+    echo "No brew logs found"
+    exit 0
+fi
+
+
+tar -cjf brew-logs.tar.bz2 ${BREWLOGS}
+tar -tf brew-logs.tar.bz2
+mv brew-logs.tar.bz2 artcd_working/doozer_working/brew-logs.tar.bz2
+rm -rf $BREWLOGS
+
+echo "Compressed brew logs:"
+ls -lh artcd_working/doozer_working/brew-logs.tar.bz2


### PR DESCRIPTION
compress brewlog function was removed from commonlib from https://github.com/openshift-eng/aos-cd-jobs/commit/f79522d15d4740d4779f970e266be86a9b8a67fe