### PR TITLE
rebuild job: define builderEmail

### DIFF
--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -96,7 +96,7 @@ node {
             cmd += [
                 "rebuild",
                 "--ocp-build-data-url", params.OCP_BUILD_DATA_URL,
-                "-g", "openshift-$params.BUILD_VERSION",
+                "--version", params.BUILD_VERSION,
                 "--assembly", params.ASSEMBLY,
                 "--type", params.TYPE
             ]
@@ -120,6 +120,9 @@ node {
                     file(credentialsId: 'art-jenkins-ldap-serviceaccount-client-cert', variable: 'RHSM_PULP_CERT'),
                 ]) {
                     echo "Will run ${cmd}"
+                    wrap([$class: 'BuildUser']) {
+                        builderEmail = env.BUILD_USER_EMAIL
+                    }
                     withEnv([
                         "BUILD_USER_EMAIL=${builderEmail?: ''}",
                         "BUILD_URL=${BUILD_URL}",


### PR DESCRIPTION
we probably don't even need it (rebuild will always be manual...) but just for consistency, define in the same way as `ocp4` etc

also fix whatever else seems broken about this job (not sure we've run since moved to `pyartcd`)