### PR TITLE
Skip crc, odo and helm in client sync job

### DIFF
--- a/jobs/build/client_sync/Jenkinsfile
+++ b/jobs/build/client_sync/Jenkinsfile
@@ -92,6 +92,10 @@ node {
 
     currentBuild.displayName = "#${currentBuild.number} - ${kind} ${params.VERSION}${(params.DRY_RUN) ? " [DRY_RUN]" : ""}"
 
+    if (kind in ["crc", "odo", "helm"]) {
+        error "${kind} is published through Content Gateway now. The mirror.openshift.com path is, under the covers, proxying the request to developers.redhat.com"
+    }
+
     stage("Validate params") {
         if (!params.VERSION) {
             error 'SOURCE_VERSION must be specified'


### PR DESCRIPTION
[Content Gateway](https://source.redhat.com/groups/public/dxd/middleware_engineering_services_mwes_wiki/redhat_developersjboss_download_manager_administration_ui) publishes these clients now. 
[Slack ref](https://redhat-internal.slack.com/archives/GDBRP5YJH/p1699563030899489)

Test run [succeeded](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/client-sync-test/2/)

_Requesting /lgtm and /approve_
