### PR TITLE
[ART-8304] Refactor Containerfile.base to use install.sh from art-tools

### DIFF
--- a/tekton-pipelines/images/artcd/Containerfile.base
+++ b/tekton-pipelines/images/artcd/Containerfile.base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 # Set metadata
 LABEL name="openshift-art/artcd-base" \
@@ -14,25 +14,27 @@ COPY tekton-pipelines/images/artcd/files/etc/yum.repos.d /etc/yum.repos.d/
 
 # Install necessary packages and Python libraries
 RUN dnf -y install python3 python3-pip python3-wheel python3-devel gcc krb5-devel wget tar gzip git krb5-workstation \
-brewkoji rhpkg \
-&& python3 -m pip install --upgrade setuptools
+    brewkoji rhpkg \
+    && python3 -m pip install --upgrade setuptools pip \
+    && dnf clean all
 
 # Set ARG for OC_VERSION
 ARG OC_VERSION=latest
 
 # Install oc client
-RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/$(arch)/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" \
+RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz" \
   && tar -C /usr/local/bin -xzvf "openshift-client-linux-$OC_VERSION.tar.gz" oc kubectl
 
-# Install repos directly from their sources
-RUN python3 -m pip install "git+https://github.com/openshift-eng/art-tools.git#egg=rh-doozer&subdirectory=doozer" \
- "git+https://github.com/openshift-eng/art-tools.git#egg=rh-elliott&subdirectory=elliott" \
- "git+https://github.com/openshift-eng/art-tools.git#egg=pyartcd&subdirectory=pyartcd"
+# Set workspace
+WORKDIR /home/dev
 
-# Clean up
-RUN dnf clean all
+# Clone art-tools into a specific directory and run the install script
+RUN git clone https://github.com/openshift-eng/art-tools.git art-tools \
+    && cd art-tools \
+    && ./install.sh \
+# Clean art-tools
+RUN rm -rf art-tools
 
 # Create a non-root user and set as current
 RUN useradd -m -d /home/dev -u 1000 dev
 USER 1000
-WORKDIR /home/dev


### PR DESCRIPTION
Updated Containerfile.base to clone and execute the install.sh script from art-tools, replacing direct pip installations. This change streamlines the build process, aligning with our updated approach for dependency management and ensuring consistency across Docker builds. Also upgraded pip alongside setuptools for better package management.