### PR TITLE
support extract file from el9

### DIFF
--- a/jobs/build/coreos-installer_sync/extract.sh
+++ b/jobs/build/coreos-installer_sync/extract.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 
 WORKDIR="$1"
 cd "$WORKDIR"

--- a/jobs/build/coreos-installer_sync/extract.sh
+++ b/jobs/build/coreos-installer_sync/extract.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 WORKDIR="$1"
 cd "$WORKDIR"
@@ -27,7 +27,11 @@ mkdir "$VERSION"
 
 for rpm in *.rpm; do
   arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}' <<<"$rpm")"
-  rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
+  if [[ "$rpm" == *el9* ]]; then
+    rpm2cpio "${rpm}" | zstd -d | cpio -idm --quiet ./usr/bin/coreos-installer
+  else
+    rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
+  fi
   mv usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
 done
 


### PR DESCRIPTION
fix coreos-installer sync job failure: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcoreos-installer_sync/17/
if coreos-installer rpm is based on el9 then cpio can't directly extract it due to  [RHEL 9 uses a payload compression (zstd) which is not be available on RHEL 7](https://bugzilla.redhat.com/show_bug.cgi?id=2058426#c3) so the pr add a check, use zstd decompress content for el9 rpm.
test job: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ximhan/job/build%252Fcoreos-installer_sync/4/console