### PR TITLE
gen-assembly: define valid values for LIMIT_ARCHES

### DIFF
--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -69,7 +69,7 @@ node {
                         ),
                         string(
                             name: 'LIMIT_ARCHES',
-                            description: '(Optional) Limit included arches to this list',
+                            description: '(Optional) Limit included arches to this list. Valid values are (aarch64, ppc64le, s390x, x86_64)',
                             defaultValue: "",
                             trim: true,
                         ),


### PR DESCRIPTION
Make it clear what valid values can be assigned to the `LIMIT_ARCHES` param