### PR TITLE
Chunk slack response in nag upstream

### DIFF
--- a/pipeline-scripts/slacklib.groovy
+++ b/pipeline-scripts/slacklib.groovy
@@ -126,7 +126,11 @@ def notifySlack(channel, as_user, text, attachments=[], thread_ts=null, replyBro
         }
 
          //print "Received slack response: ${response}\n\n"
-         return readJSON(text: response.content)
+        def responseJson = readJSON(text: response.content)
+        if (!responseJson.ok) {
+            error("slack response not ok:\n ${response.content}\n")
+        }
+        return responseJson
     }
 }
 


### PR DESCRIPTION
Slack throws an error when text exceeds 3000 chars
https://api.slack.com/reference/block-kit/blocks#section
so chunk response every 2000 chars

Test build
https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fnag-upstream/5/console

https://redhat-internal.slack.com/archives/C06625LHXQS/p1707324740747989