### PR TITLE
remove validate-rhsa

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -235,39 +235,40 @@ node {
         }
     }
 
-    stage("validate RHSAs") {
-        if (release_info.type == "custom" || release_info.type == "preview") {
-            echo "Skipping RHSA check for custom (hotfix) or preview release."
-            return
-        }
+    // SFM2 central server is no longer operational
+    // stage("validate RHSAs") {
+    //     if (release_info.type == "custom" || release_info.type == "preview") {
+    //         echo "Skipping RHSA check for custom (hotfix) or preview release."
+    //         return
+    //     }
 
-        if (params.DRY_RUN) {
-            return
-        }
+    //     if (params.DRY_RUN) {
+    //         return
+    //     }
 
-        def advisory_map = release.getAdvisories("openshift-${params.VERSION}")?: [:]
-        advisory_map.each { k, v ->
-            if (v <= 0) {
-                return
-            }
-            advisory_id = "$v"
-            res = commonlib.shell(
-                script: "elliott validate-rhsa ${advisory_id}",
-                returnAll: true,
-            )
-            if (res.returnStatus != 0) {
-                msg = """
-                    Review of CVE situation required for advisory <https://errata.devel.redhat.com/advisory/${advisory_id}|${advisory_id}>.
-                    Report:
-                    ```
-                    ${res.stdout}
-                    ```
-                    Note: For GA image advisories this is expected to fail.
-                """.stripIndent()
-                slacklib.to(params.VERSION).say(msg)
-            }
-        }
-    }
+    //     def advisory_map = release.getAdvisories("openshift-${params.VERSION}")?: [:]
+    //     advisory_map.each { k, v ->
+    //         if (v <= 0) {
+    //             return
+    //         }
+    //         advisory_id = "$v"
+    //         res = commonlib.shell(
+    //             script: "elliott validate-rhsa ${advisory_id}",
+    //             returnAll: true,
+    //         )
+    //         if (res.returnStatus != 0) {
+    //             msg = """
+    //                 Review of CVE situation required for advisory <https://errata.devel.redhat.com/advisory/${advisory_id}|${advisory_id}>.
+    //                 Report:
+    //                 ```
+    //                 ${res.stdout}
+    //                 ```
+    //                 Note: For GA image advisories this is expected to fail.
+    //             """.stripIndent()
+    //             slacklib.to(params.VERSION).say(msg)
+    //         }
+    //     }
+    // }
 
     stage("clean and mail") {
         dry_subject = ""


### PR DESCRIPTION
The http://sfm2.prodsec.redhat.com/ server is no longer operational, we can't use it anymore and their service move to a place where only errata can access, so deprecate this step for now.

https://redhat-internal.slack.com/archives/GDBRP5YJH/p1707370865294469