### PR TITLE
Skip plashets in ocp4 builds by default; automation will re-enable them

### DIFF
--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -116,7 +116,7 @@ node {
                     booleanParam(
                         name: 'SKIP_PLASHETS',
                         description: 'Do not build plashets (for example to save time when running multiple builds against test assembly)',
-                        defaultValue: false,
+                        defaultValue: true,
                     ),
                     booleanParam(
                         name: 'COMMENT_ON_PR',


### PR DESCRIPTION
Needs to go along with https://github.com/openshift-eng/art-tools/pull/431