### PR TITLE
Remove snippet from art-attention

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
+++ b/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
@@ -94,13 +94,8 @@ if __name__ == '__main__':
                     age_type = 'days'
 
         age = int(age)
-        # Block builder: https://app.slack.com/block-kit-builder/T04714LEPHA#%7B%22blocks%22:%5B%5D%7D
-        snippet = ' '.join(text.split(' ')[0:30])
-        # Slack includes an arrow character in the text if should be replaced by rich text elements (e.g. a n@username).
-        # We just remove them since we are just trying for a short summary.
-        snippet = snippet.replace('\ue006', '...')
         response_messages.append(
-            f"*Channel:* {channel_handle}\n*Date:* {str_date}Z\n*Age:* {age} {age_type}\n*Message:* <{permalink}|Link>\n*Snippet:* {snippet}...")
+            f"*Channel:* {channel_handle}\n*Date:* {str_date}Z\n*Age:* {age} {age_type}\n*Message:* <{permalink}|Link>")
 
     header_block = [
         {


### PR DESCRIPTION
A message preview with better formatting (e.g. unfurled links) is already being shown thanks to the `Link` field