### PR TITLE
ART-9183 Add rclone() wrapper function

### DIFF
--- a/jobs/build/buildvm-maint/Jenkinsfile
+++ b/jobs/build/buildvm-maint/Jenkinsfile
@@ -72,7 +72,7 @@ node('openshift-build-1') {
                         // Want to see what's in the snapshots directory?
                         //   $ rclone tree s3SigningLogs:art-build-artifacts/buildvm-snapshots/
                         try {
-                            sh("/bin/rclone -v copyto /home/jenkins/new_snapshot.txt s3SigningLogs:art-build-artifacts/buildvm-snapshots/`date '+%Y%m%d'`.txt")
+                            buildlib.rclone("-v copyto /home/jenkins/new_snapshot.txt s3SigningLogs:art-build-artifacts/buildvm-snapshots/`date '+%Y%m%d'`.txt")
                         } catch ( snapErr ) {
                             errors[4] = snapErr
                             def snapshot = readFile("/home/jenkins/new_snapshot.txt")

--- a/jobs/build/set_client_latest/Jenkinsfile
+++ b/jobs/build/set_client_latest/Jenkinsfile
@@ -83,7 +83,11 @@ node {
             error("Released ocp client links are managed automatically by polling Cincinnati. See set_cincinnati_links in scheduled-jobs")
         }
 
-        withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        withCredentials([
+                aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'),
+                aws(credentialsId: 'aws-s3-signing-logs', accessKeyVariable: 'SIGNING_LOGS_ACCESS_KEY', secretKeyVariable: 'SIGNING_LOGS_SECRET_ACCESS_KEY'),
+                aws(credentialsId: 'aws-s3-osd-art-account', accessKeyVariable: 'OSD_ART_ACCOUNT_ACCESS_KEY', secretKeyVariable: 'OSD_ART_ACCOUNT_SECRET_ACCESS_KEY')]) {
+
             withEnv(["FORCE_UPDATE=${params.FORCE_UPDATE? '1' : '0'}"]){
                 commonlib.shell("./S3-set-v4-client-latest.sh ${params.CHANNEL_OR_RELEASE} ${params.CLIENT_TYPE} ${params.LINK_NAME} ${params.ARCHES}")
             }

--- a/jobs/signing/sign-artifacts/Jenkinsfile
+++ b/jobs/signing/sign-artifacts/Jenkinsfile
@@ -481,14 +481,14 @@ node {
         //       consider for syncing if they are already on the remote
         def logCopyOpts = "--verbose copy --s3-chunk-size 5M --exclude 'program.dat' --no-traverse --max-age 24h --retries-sleep 10s --ignore-existing --local-no-check-updated --low-level-retries 1 --retries 5 ${buildArtifactPath} s3SigningLogs:art-build-artifacts/signing-jobs/signing%2Fsign-artifacts/"
 
-	sh "/bin/rclone version"
+	    buildlib.rclone("version")
 
         if ( !params.DRY_RUN ) {
-            sh "/bin/rclone ${logCopyOpts}"
+            buildlib.rclone("${logCopyOpts}")
         } else {
             echo "DRY-RUN, not syncing logs (but this would have happened):"
             echo "Artifact path (source to sync): ${buildArtifactPath}"
-            sh "/bin/rclone --dry-run ${logCopyOpts}"
+            buildlib.rclone("--dry-run ${logCopyOpts}")
         }
     }
 


### PR DESCRIPTION
rclone is using a default configuration file stored at /home/jenkins/.config/rclone/rclone.conf. This file currently carries AWS secrets in clear text. This PR proposes a different approach:
- store the secrets in Jenkins (already done)
- turn the config file into a template, where the secrets are replaced with env vars
- at runtime, render the template by filling the placeholders with real values coming from Jenkins (use `envsubst` for this`
- call `rclone` with the `--config` option, pointing to the locally rendered file
- when done, remove the rendered file (do that in a `finally` block to make sure this always happens)