### PR TITLE
microshift_sync: Tweak sign check message

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -144,7 +144,7 @@ node {
                     # we just want proof of a key.
                     sign_result=`rpm -K $rpm`
                     set -e
-                    echo "$sign_result" | grep -i pgp   # fail if RPM does not appear signed now
+                    echo "$sign_result" | grep -i "digests signatures OK"   # fail if RPM does not appear signed now
                 ''' + """
                 done
 


### PR DESCRIPTION
rpm -K output format has changed since moving buildvm.
Now it doesn't output the expected "rsa sha1 (md5) pgp md5 OK"
but "digests signatures OK"

I've tested this on buildvm locally. 
If we want more rigorous check,
`rpm -v -K` is an alternative with which we can verify the key_id matches what we expect