### PR TITLE
Enable only_stream for sync-ci-images

### DIFF
--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -134,6 +134,9 @@ node {
 
             echo "Changes detected in ocp-build-data group: ${group}"
             currentBuild.displayName += " ${version}"
+            if (params.ONLY_STREAM) {
+                currentBuild.displayName += " ${params.ONLY_STREAM}"
+            }
 
             doozerWorking = "${env.WORKSPACE}/wd-${version}"
             def doozerOpts = "--working-dir ${doozerWorking} --group ${group} "

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -88,13 +88,16 @@ node {
     }
 
     def streamParam = ""
+    def skip_prs = params.SKIP_PRS
     if (params.ONLY_STREAM) {
         if (!params.ONLY_RELEASE) {
             error("ONLY_STREAM can only be used with ONLY_RELEASE")
         }
-        echo "Setting SKIP_PRS to true because ONLY_STREAM is set"
-        params.SKIP_PRS = true
-        def streamParam = "--stream ${params.ONLY_STREAM}"
+        if (!skip_prs) {
+            echo "Setting SKIP_PRS to true because ONLY_STREAM is set"
+            skip_prs = true
+        }
+        streamParam = "--stream ${params.ONLY_STREAM}"
     }
 
     buildlib.withAppCiAsArtPublish() {
@@ -155,7 +158,7 @@ node {
                     buildlib.doozer("${doozerOpts} images:streams check-upstream")
 
                     // Open reconciliation PRs
-                    if (params.SKIP_PRS) {
+                    if (skip_prs) {
                         echo "Skipping opening PRs"
                     } else {
                         withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -29,6 +29,12 @@ node {
                     trim: true,
                 ),
                 string(
+                    name: 'ONLY_STREAM',
+                    description: 'The name of the stream (not `assembly=stream` but `stream=golang`) from streams.yml that you want to run for. This only works with ONLY_RELEASE, and SKIP_PRS will be set to true.',
+                    defaultValue: "",
+                    trim: true,
+                ),
+                string(
                     name: "ADD_LABELS",
                     description: "Space delimited list of labels to add to existing/new PRs",
                     defaultValue: "",
@@ -40,6 +46,12 @@ node {
                     defaultValue: "stream",
                     trim: true,
                 ),
+                [
+                    name: 'SKIP_PRS',
+                    description: 'Skip opening PRs, do everything else',
+                    $class: 'BooleanParameterDefinition',
+                    defaultValue: false
+                ],
                 [
                     name: 'SKIP_WAITS',
                     description: 'Skip sleeps',
@@ -73,6 +85,16 @@ node {
 
     if (params.FORCE_RUN) {
         currentBuild.displayName += " (forced)"
+    }
+
+    def streamParam = ""
+    if (params.ONLY_STREAM) {
+        if (!params.ONLY_RELEASE) {
+            error("ONLY_STREAM can only be used with ONLY_RELEASE")
+        }
+        echo "Setting SKIP_PRS to true because ONLY_STREAM is set"
+        params.SKIP_PRS = true
+        def streamParam = "--stream ${params.ONLY_STREAM}"
     }
 
     buildlib.withAppCiAsArtPublish() {
@@ -117,13 +139,13 @@ node {
             try {
                 sshagent(["openshift-bot"]) {
                     sh "rm -rf ${doozerWorking}"
-                    buildlib.doozer("${doozerOpts} images:streams gen-buildconfigs -o ${group}.yaml --apply")
+                    buildlib.doozer("${doozerOpts} images:streams gen-buildconfigs ${streamParam} -o ${group}.yaml --apply")
                     mirror_args = ""
                     if ( params.UPDATE_IMAGES_ONLY_WHEN_MISSING ) {
                         mirror_args += "--only-if-missing "
                     }
-                    buildlib.doozer("${doozerOpts} images:streams mirror ${mirror_args}")
-                    buildlib.doozer("${doozerOpts} images:streams start-builds")
+                    buildlib.doozer("${doozerOpts} images:streams mirror ${streamParam} ${mirror_args}")
+                    buildlib.doozer("${doozerOpts} images:streams start-builds ${streamParam}")
 
                     if (!params.SKIP_WAITS) {
                         // Allow the builds to run for about 20 minutes
@@ -131,20 +153,26 @@ node {
                     }
                     // Print out status of builds for posterity
                     buildlib.doozer("${doozerOpts} images:streams check-upstream")
-                    withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
-                        if ( (major == 4 && minor >= 12) || major > 4 ) {
-                            other_args = '--add-label "bugzilla/valid-bug" --add-label "cherry-pick-approved" --add-label "backport-risk-assessed"'
-                            for ( label in params.ADD_LABELS.split() ) {
-                                other_args += " --add-label '${label}'"
-                            }
-                            // Only open PRs on >= 4.6 to leave well enough alone.
-                            withEnv(["BUILD_URL=${BUILD_URL}"]) {
-                                rc = sh script:"doozer ${doozerOpts} --assembly stream images:streams prs open --interstitial 840 --add-auto-labels ${other_args} --github-access-token ${GITHUB_TOKEN}", returnStatus: true
-                            }
-                            // rc=50 is used to indicate some errors raised during PR openings
-                            // rc=25 is used to indicate PR openings were skipped and to try again later.
-                            if ( rc != 0 && rc != 25 && rc != 50) {
-                                error("Error opening PRs for ${group}: ${rc}")
+
+                    // Open reconciliation PRs
+                    if (params.SKIP_PRS) {
+                        echo "Skipping opening PRs"
+                    } else {
+                        withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                            if ( (major == 4 && minor >= 12) || major > 4 ) {
+                                other_args = '--add-label "bugzilla/valid-bug" --add-label "cherry-pick-approved" --add-label "backport-risk-assessed"'
+                                for ( label in params.ADD_LABELS.split() ) {
+                                    other_args += " --add-label '${label}'"
+                                }
+                                // Only open PRs on >= 4.6 to leave well enough alone.
+                                withEnv(["BUILD_URL=${BUILD_URL}"]) {
+                                    rc = sh script:"doozer ${doozerOpts} --assembly stream images:streams prs open --interstitial 840 --add-auto-labels ${other_args} --github-access-token ${GITHUB_TOKEN}", returnStatus: true
+                                }
+                                // rc=50 is used to indicate some errors raised during PR openings
+                                // rc=25 is used to indicate PR openings were skipped and to try again later.
+                                if ( rc != 0 && rc != 25 && rc != 50) {
+                                    error("Error opening PRs for ${group}: ${rc}")
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
To enable the usecase of running sync-ci-images for a specific stream (eg. https://github.com/openshift-eng/ocp-build-data/pull/4664)

Sometimes we want to enable/operate on a stream quickly, while ignoring everything else.
Our doozer commands `images:streams` support specifying `--stream` so enable those in the job.
Also we want to skip opening PRs, in cases like these so have that as well.

Should go after https://github.com/openshift-eng/art-tools/pull/548

Test run:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Fsync-ci-images/6/