### PR TITLE
Add login for quay.io/openshift/ci (DPTP's QCI) registry

### DIFF
--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -101,7 +101,16 @@ node {
     }
 
     buildlib.withAppCiAsArtPublish() {
+
+        // Log in to app.ci's internal registry as we push some images there (registry.ci.openshift.org).
         sh "oc registry login"
+
+        // Log in to quay.io with credentials necessary to push to DPTP's QCI registry (quay.io/openshift/ci). QCI
+        // will eventually be the source of truth for images being used by CI workloads instead of app.ci's internal registry.
+        // We support this by mirroring important images directly to QCI.
+        withCredentials([usernamePassword(credentialsId: 'art_to_ci_promotion_robot--qci', usernameVariable: '$QCI_USER', passwordVariable: 'QCI_PASSWORD')]) {
+            sh "oc registry login --registry=quay.io/openshift --auth-basic=$QCI_USER:QCI_PASSWORD"
+        }
 
         for ( String version : for_versions ) {
             group = "openshift-${version}"


### PR DESCRIPTION
DPTP is moving to use QCI as the source of truth for their CI images. To support this, ART should mirror images both to registry.ci.openshift.org and QCI.
When mapping from registry.ci.openshift.org location to a QCI location, use the format:
 `quay.io/openshift/ci:<namespace>_<imagestream>_<tag_name>`