### PR TITLE
consolidate invalidate aws cache commands

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -173,17 +173,6 @@ node {
                         commonlib.syncRepoToS3Mirror(mirror_src, mirror_path, true, 10, dry_run)
                         if (set_latest) {
                             commonlib.syncRepoToS3Mirror(mirror_src, latest_path, true, 10, dry_run)
-                            // https://issues.redhat.com/browse/ART-6607 on why invalidation matters when updating
-                            // existing filenames.
-                            withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-                                commonlib.shell(script:"""
-                                aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${latest_path}/*"
-                                """)
-
-                                commonlib.shell(script:"""
-                                aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "${mirror_path}/*"
-                                """)
-                            }
                         }
                     }
                 }

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -575,7 +575,22 @@ def checkS3Path(s3_path) {
     }
 }
 
-def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, dry_run=false) {
+def invalidateAwsCache(s3_path) {
+    // https://issues.redhat.com/browse/ART-6607 on why invalidation matters when updating existing filenames.
+
+    invalidation_path = s3_path
+    if ( !invalidation_path.endsWith('/') ) {
+      invalidation_path += '/'
+    }
+    invalidation_path += '*'
+
+    withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+        shell(script: "aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths ${invalidation_path}")
+    }
+
+}
+
+def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, issue_cloudfront_invalidation=true, dry_run=false) {
     try {
         checkS3Path(s3_path)
         withCredentials([aws(credentialsId: 's3-art-srv-enterprise', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
@@ -599,6 +614,9 @@ def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, 
                     }
                 }
             }
+            if (issue_cloudfront_invalidation) {
+                invalidateAwsCache(s3_path)
+            }
         }
     } catch (e) {
         slacklib.to("#art-release").say("Failed syncing ${local_dir} repo to art-srv-enterprise S3 path ${s3_path}")
@@ -606,7 +624,7 @@ def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, 
     }
 }
 
-def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', timeout_minutes=60) {
+def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', timeout_minutes=60, issue_cloudfront_invalidation=true) {
     try {
         checkS3Path(s3_path)
         extra_args = ""
@@ -622,6 +640,9 @@ def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', time
                 timeout(time: timeout_minutes, unit: 'MINUTES') { // aws s3 sync has been observed to hang before
                     shell(script: "aws s3 sync --no-progress --exact-timestamps ${extra_args} ${local_dir} s3://art-srv-enterprise${s3_path}")
                 }
+            }
+            if (issue_cloudfront_invalidation) {
+                 invalidateAwsCache(s3_path)
             }
         }
     } catch (e) {


### PR DESCRIPTION
Since it takes time to reflect the change in the `/latest` dir

Referred to microshift sync [distribution id](https://github.com/openshift-eng/aos-cd-jobs/blob/f215ff6894167f0c0d8c81039b04f936e7e87621/jobs/build/microshift_sync/Jenkinsfile#L180)