### PR TITLE
Revert "Bump early operator index to track 4.17"

### DIFF
--- a/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
+++ b/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
@@ -17,9 +17,9 @@ node {
 
     workDir = "${env.WORKSPACE}/doozer_working"
     sh "rm -rf ${workDir}"
-    ocpVer = "4.17"
-    operatorIndexBaseVersion = "4.16"
-    operatorRegistryVersion = "4.16"
+    ocpVer = "4.16"
+    operatorIndexBaseVersion = "4.15"
+    operatorRegistryVersion = "4.15"
     
     // Print out bundle pullspecs alongside of distgit keys to help identify bundles which have not been built yet.
     echo "Doozer pullspecs by distgit_key"


### PR DESCRIPTION
This reverts commit 5b43cec3754025731508a104be7845966f498497.
This PR has to be re-reverted when the branch cut [4.17] happens