### PR TITLE
Filter out eol versions when running scheduled-jobs

### DIFF
--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -28,7 +28,7 @@ node {
             disableConcurrentBuilds(),
     ])
 
-    versions = commonlib.ocp4Versions()
+    versions = commonlib.ocp4VersionsForRelease()
     // Send UMB messages for these new nightlies, yields a list like:
     //     [[4.6.0-0.nightly, 4.6.0-0.nightly-s390x, ..], 4.5.0-0.nightly, 4.4.0-0.nightly, ...]
     def nightlies = versions.collect { version -> return commonlib.goArchSuffixes.collect { version + ".0-0.nightly" + it } }

--- a/jobs/build/send-umb-messages/Jenkinsfile
+++ b/jobs/build/send-umb-messages/Jenkinsfile
@@ -28,12 +28,13 @@ node {
             disableConcurrentBuilds(),
     ])
 
+    versions = commonlib.ocp4Versions()
     // Send UMB messages for these new nightlies, yields a list like:
     //     [[4.6.0-0.nightly, 4.6.0-0.nightly-s390x, ..], 4.5.0-0.nightly, 4.4.0-0.nightly, ...]
-    def nightlies = commonlib.ocp4Versions.collect { version -> return commonlib.goArchSuffixes.collect { version + ".0-0.nightly" + it } }
+    def nightlies = versions.collect { version -> return commonlib.goArchSuffixes.collect { version + ".0-0.nightly" + it } }
     // Send UMB messages for these new stables, yields a list like:
     //     [[4-stable:4.6, 4-stable-s390x:4.6, ..], 4-stable:4.5, 4-stable:4.4, ...]
-    def stables = commonlib.ocp4Versions.collect { version -> return commonlib.goArchSuffixes.collect { "4-stable" + it + ":" + version } }
+    def stables = versions.collect { version -> return commonlib.goArchSuffixes.collect { "4-stable" + it + ":" + version } }
     def releaseStreams = stables.flatten() + nightlies.flatten()
     currentBuild.description = ""
     // currentBuild.displayName = ""

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -6,8 +6,9 @@ ocp3Versions = [
 ]
 
 // Recent and relevant versions of ocp4
-// versions could be EOL
-// See: ocp4Versions() instead
+// that we need to build for
+// versions could be EOL.
+// Use ocp4VersionsForRelease() for the list of versions that are not EOL
 ocp4Versions = [
     "4.17",
     "4.16",
@@ -47,11 +48,11 @@ def getEOLVersions(ocp_major_version) {
     return eol_versions
 }
 
-def ocp4Versions() {
+def ocp4VersionsForRelease() {
     eolVersions = getEOLVersions('4')
     echo "EOL Versions: ${eolVersions}"
     found = ocp4Versions.findAll { it -> !eolVersions.contains(it) }
-    echo "OCP4 Versions: ${found}"
+    echo "OCP4 Versions for release: ${found}"
     return found
 }
 

--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -11,7 +11,11 @@ node {
     ] )
 
     def versionJobs = [:]
-    for ( version in commonlib.ocp4Versions() ) {
+    // ocp4_scan relies on `freeze_automation` config to determine whether to build or not
+    // so we do not want to use commonlib.ocp4VersionsForRelease() here, since it is filters versions
+    // by `software_lifecycle: phase: eol`
+    // And those are independent. We sometimes want to keep building EOL versions
+    for ( version in commonlib.ocp4Versions ) {
         def cv = "${version}" // make sure we use a locally scoped variable
 
         // Skip the build if already locked

--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     ] )
 
     def versionJobs = [:]
-    for ( version in commonlib.ocp4Versions ) {
+    for ( version in commonlib.ocp4Versions() ) {
         def cv = "${version}" // make sure we use a locally scoped variable
 
         // Skip the build if already locked

--- a/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -28,7 +28,7 @@ def runFor(version) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions.sort(false)
+  return commonlib.ocp4Versions().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/scheduled-jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -28,7 +28,7 @@ def runFor(version) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions().sort(false)
+  return commonlib.ocp4VersionsForRelease().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/build/scan-osh/Jenkinsfile
+++ b/scheduled-jobs/build/scan-osh/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     ] )
 
     def versionJobs = [:]
-    for ( version in commonlib.ocp4Versions ) {
+    for ( version in commonlib.ocp4Versions() ) {
         def cv = "${version}" // make sure we use a locally scoped variable
 
         // Trigger SAST scan for ${version}

--- a/scheduled-jobs/build/scan-osh/Jenkinsfile
+++ b/scheduled-jobs/build/scan-osh/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     ] )
 
     def versionJobs = [:]
-    for ( version in commonlib.ocp4Versions() ) {
+    for ( version in commonlib.ocp4VersionsForRelease() ) {
         def cv = "${version}" // make sure we use a locally scoped variable
 
         // Trigger SAST scan for ${version}

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -3,7 +3,7 @@
 @NonCPS
 def sortedVersions() {
     // Proceed from newest to oldest to prioritize a functional run on the latest version.
-    return commonlib.ocp4Versions.sort(false).reverse()
+    return commonlib.ocp4Versions().sort(false).reverse()
 }
 
 node {

--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -3,7 +3,7 @@
 @NonCPS
 def sortedVersions() {
     // Proceed from newest to oldest to prioritize a functional run on the latest version.
-    return commonlib.ocp4Versions().sort(false).reverse()
+    return commonlib.ocp4VersionsForRelease().sort(false).reverse()
 }
 
 node {

--- a/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
@@ -6,7 +6,7 @@ properties([
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions.sort(false)
+  return commonlib.ocp4Versions().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci-ironic/Jenkinsfile
@@ -6,7 +6,7 @@ properties([
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions().sort(false)
+  return commonlib.ocp4VersionsForRelease().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -39,7 +39,7 @@ def runFor(group, dir, arch="x86_64") {
 def sortedVersions() {
   // Return versions honoring semver, but exclude disabled
   def disabled = []
-  def s = commonlib.ocp4Versions.sort(false) {
+  def s = commonlib.ocp4Versions().sort(false) {
     def major_minor = it.tokenize('.')
 
     assert major_minor.size() == 2

--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -39,7 +39,7 @@ def runFor(group, dir, arch="x86_64") {
 def sortedVersions() {
   // Return versions honoring semver, but exclude disabled
   def disabled = []
-  def s = commonlib.ocp4Versions().sort(false) {
+  def s = commonlib.ocp4VersionsForRelease().sort(false) {
     def major_minor = it.tokenize('.')
 
     assert major_minor.size() == 2

--- a/scheduled-jobs/build/tag-rpms/Jenkinsfile
+++ b/scheduled-jobs/build/tag-rpms/Jenkinsfile
@@ -28,7 +28,7 @@ def runFor(version) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions.sort(false)
+  return commonlib.ocp4Versions().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/build/tag-rpms/Jenkinsfile
+++ b/scheduled-jobs/build/tag-rpms/Jenkinsfile
@@ -28,7 +28,7 @@ def runFor(version) {
 
 @NonCPS
 def sortedVersions() {
-  return commonlib.ocp4Versions().sort(false)
+  return commonlib.ocp4VersionsForRelease().sort(false)
 }
 
 node() {

--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -32,7 +32,7 @@ def runFor(version, channelPrefix, linkName) {
 @NonCPS
 def sortedVersions() {
   // Return versions honoring semver
-  return commonlib.ocp4Versions().sort(false) {
+  return commonlib.ocp4VersionsForRelease().sort(false) {
     def major_minor = it.tokenize('.')
 
     assert major_minor.size() == 2

--- a/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
+++ b/scheduled-jobs/maintenance/set_cincinnati_links/Jenkinsfile
@@ -32,7 +32,7 @@ def runFor(version, channelPrefix, linkName) {
 @NonCPS
 def sortedVersions() {
   // Return versions honoring semver
-  return commonlib.ocp4Versions.sort(false) {
+  return commonlib.ocp4Versions().sort(false) {
     def major_minor = it.tokenize('.')
 
     assert major_minor.size() == 2


### PR DESCRIPTION
To mark a version eol we have 2 places, one is our group.yml config and another
is ocp4Versions constant in this repo. We have marking version as eol in config, but
jobs still run for all versions in ocp4Versions. This is so that we filter these eol versions
out for jobs that don't need to run for eol versions.

Test:
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Focp4_scan/17/console