### PR TITLE
build-sync print oc version for client only

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -142,7 +142,7 @@ node('covscan') {
     stage("Version dumps") {
         buildlib.doozer "--version"
         buildlib.elliott "--version"
-        buildlib.oc("version -o yaml")
+        buildlib.oc("version --client=true -o yaml")
     }
 
     stage ("build sync") {


### PR DESCRIPTION
Do not error out if we are not logged in to server