### PR TITLE
Revert "Archive artifacts tweak"

### DIFF
--- a/jobs/build/prepare-release/Jenkinsfile
+++ b/jobs/build/prepare-release/Jenkinsfile
@@ -141,16 +141,10 @@ node {
         } finally {
             commonlib.safeArchiveArtifacts([
                 "artcd_working/email/**",
-                "artcd_working/doozer_working/*.log",
-                "artcd_working/doozer_working/*.yaml",
-                "artcd_working/doozer_working/*.yml"
-                "artcd_working/elliott_working/*.log",
-                "artcd_working/elliott_working/*.yaml",
-                "artcd_working/elliott_working/*.yml"
-                "artcd_working/*.json",
-                "artcd_working/*.log",
-                "artcd_working/*.yaml",
-                "artcd_working/*.yml",
+                "artcd_working/**/*.json",
+                "artcd_working/**/*.log",
+                "artcd_working/**/*.yaml",
+                "artcd_working/**/*.yml",
             ])
             buildlib.cleanWorkspace()
         }

--- a/jobs/build/tag-rpms/Jenkinsfile
+++ b/jobs/build/tag-rpms/Jenkinsfile
@@ -83,9 +83,11 @@ node {
             throw err
         } finally {
             commonlib.safeArchiveArtifacts([
-                "artcd_working/doozer_working/*.log",
-                "artcd_working/doozer_working/*.yaml",
-                "artcd_working/doozer_working/*.yml"
+                "artcd_working/email/**",
+                "artcd_working/**/*.json",
+                "artcd_working/**/*.log",
+                "artcd_working/**/*.yaml",
+                "artcd_working/**/*.yml",
             ])
             buildlib.cleanWorkspace()
         }

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -647,8 +647,8 @@ def watch_brew_task_and_retry(name, taskId, brewUrl) {
     }
 }
 
-def cleanWorkspace(cleanWhenFailure=true) {
-    cleanWs(cleanWhenFailure: cleanWhenFailure, notFailBuild: true)
+def cleanWorkspace() {
+    cleanWs(cleanWhenFailure: false, notFailBuild: true)
     dir("${workspace}@tmp") {
         deleteDir()
     }


### PR DESCRIPTION
Reverts openshift-eng/aos-cd-jobs#4147

failed prepare-release job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fprepare-release/91/console
and for tag-rpm job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Ftag-rpms/24384/console
Archiving artifacts
‘artcd_working/doozer_working/*.log’ doesn’t match anything: ‘artcd_working’ exists but not ‘artcd_working/doozer_working/*.log’
No artifacts found that match the file pattern "artcd_working/doozer_working/*.log". Configuration error?
[Pipeline] archiveArtifacts
Archiving artifacts
‘artcd_working/doozer_working/*.yaml’ doesn’t match anything: ‘artcd_working’ exists but not ‘artcd_working/doozer_working/*.yaml’
No artifacts found that match the file pattern "artcd_working/doozer_working/*.yaml". Configuration error?
[Pipeline] archiveArtifacts
Archiving artifacts
‘artcd_working/doozer_working/*.yml’ doesn’t match anything: ‘artcd_working’ exists but not ‘artcd_working/doozer_working/*.yml’
No artifacts found that match the file pattern "artcd_working/doozer_working/*.yml". Configuration error?