### PR TITLE
Fix origin-web-console repo stage

### DIFF
--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -505,6 +505,7 @@ node {
 
 
             stage("origin-web-console repo") {
+                sh "go mod init go-bindata"
                 sh "go get github.com/jteeuwen/go-bindata"
                 // defines:
                 //   WEB_CONSOLE_DIR


### PR DESCRIPTION
Currently failing with

```
[Pipeline] { (origin-web-console repo)
[Pipeline] sh
+ go get github.com/jteeuwen/go-bindata
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```