### PR TITLE
update rpm sign method

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -124,21 +124,10 @@ node {
                 # See https://issues.redhat.com/browse/ART-4221 for more information about
                 # setting up signing on buildvm.
 
-                # For each RPM in the staging directory, run signing. This is lunacy because
-                # rpm --addsign will not run without prompting for a passphrase. It also can't
-                # just take this from something like: echo '' | rpm --addsign ...
-                # because it reopens /dev/tty before it tries to read the passphase. It will
-                # then pass that string on to gpg. This means even something like gpg-agent
-                # can't be used.
-                # SO, we use 'screen' to create a disconnected session running the command
-                # and use 'stuff' to stuff a new line into the stdin of the session.
-                screen_name=microshift-rpm
+                # For each RPM in the staging directory, run signing.
                 for rpm in `find ${STAGING_PLASHET_DIR} -name '*.rpm'`; do """ + '''
                     echo signing $rpm
-                    screen -d -m -S $screen_name rpm --addsign $rpm
-                    sleep 4  # some time to make sure we are at the prompt
-                    screen -S $screen_name -p 0 -X stuff "^M"
-                    sleep 4  # wait for rpm to be signed
+                    rpm --addsign $rpm
                     set +e
                     # rpm -K will throw an error if the key is not in the rpm database; we don't care
                     # we just want proof of a key.


### PR DESCRIPTION
the latest version of rpmsign cli don't need prompt

if its already signed, then it will quit
```
$ rpmsign --resign microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm 
microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm:
gpg: Note: RFC4880bis features are enabled.
gpg: writing to 'microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm.sig'
gpg: RSA/SHA256 signature from: "BF1DB2425CD7BF6A Red Hat OpenShift Release Team <aos-art-team@redhat.com>"
warning: microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm already contains identical signature, skipping
```
if it's not signed, then sign process will auto complete
```
$ rpmsign --addsign microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm 
microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm:
gpg: Note: RFC4880bis features are enabled.
gpg: writing to 'microshift-greenboot-4.16.0~rc.1-202405101626.p0.g1407777.assembly.rc.1.el9.noarch.rpm.sig'
gpg: RSA/SHA256 signature from: "BF1DB2425CD7BF6A Red Hat OpenShift Release Team <aos-art-team@redhat.com>"
```
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ximhan/job/build%252Fmicroshift_sync/4/console