### PR TITLE
Notify when no unresolved threads are found

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
+++ b/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
@@ -1,28 +1,45 @@
-properties([
-    buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
-    disableConcurrentBuilds(),
-    disableResume(),
-])
 
 node() {
     checkout scm
     commonlib = load("pipeline-scripts/commonlib.groovy")
     slacklib = commonlib.slacklib
 
-    try {
-        withCredentials([
-                            string(credentialsId: "art-bot-slack-token", variable: "SLACK_API_TOKEN"),
-                            string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
-                            string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
-                        ]) {
-            retry(10) {
-                commonlib.shell(script: "python -- scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py")
+    properties([
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
+        disableConcurrentBuilds(),
+        disableResume(),
+        [
+            $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                string(
+                        name: 'CHANNEL',
+                        description: 'Where should we notify about ART threads',
+                        trim: true,
+                        defaultValue: "#team-art"
+                    ),
+                commonlib.mockParam(),
+            ]
+        ]
+    ])
+
+    commonlib.checkMock()
+
+    stage('Check unresolved ART threads') {
+        try {
+            withCredentials([
+                                string(credentialsId: "art-bot-slack-token", variable: "SLACK_API_TOKEN"),
+                                string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
+                                string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
+                            ]) {
+                withEnv(["CHANNEL=${params.CHANNEL}"]) {
+                    retry(10) {
+                        commonlib.shell(script: "python -- scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py")
+                    }
+                }
             }
+        } catch (e) {
+            slacklib.to('#team-art').say("Error while checking unresolved threads: ${env.BUILD_URL}")
+            throw(e)
         }
-    } catch (e) {
-        slacklib.to('#team-art').say("Error while checking unresolved threads: ${env.BUILD_URL}")
-        throw(e)
     }
-
 }
-

--- a/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
+++ b/scheduled-jobs/scanning/unresolved-art-threads/unresolved-thread-notification.py
@@ -11,8 +11,8 @@ from slack_sdk.errors import SlackApiError
 SLACK_API_TOKEN = os.getenv('SLACK_API_TOKEN')
 SLACK_SIGNING_SECRET = os.getenv('SLACK_SIGNING_SECRET')
 USER_TOKEN = os.getenv('SLACK_USER_TOKEN')
+CHANNEL = os.getenv('CHANNEL')
 
-TEAM_ART_CHANNEL = 'team-art'
 RELEASE_ARTIST_HANDLE = 'release-artists'
 
 
@@ -42,6 +42,10 @@ if __name__ == '__main__':
 
     if not all_matches:
         print('No messages matching attention emoji criteria')
+        response = app.client.chat_postMessage(
+            channel=CHANNEL,
+            text=f':check: no unresolved threads found'
+        )
         exit(0)
 
     print(json.dumps(all_matches))
@@ -116,18 +120,18 @@ if __name__ == '__main__':
     ]
 
     # https://api.slack.com/methods/chat.postMessage#examples
-    response = app.client.chat_postMessage(channel=TEAM_ART_CHANNEL,
+    response = app.client.chat_postMessage(channel=CHANNEL,
                                            text=f'@{RELEASE_ARTIST_HANDLE} - {fallback_text}',
                                            blocks=header_block,
                                            unfurl_links=False)
 
     # Post warnings about inaccessible channels first
     for warning in channel_warnings.values():
-        app.client.chat_postMessage(channel=TEAM_ART_CHANNEL,
+        app.client.chat_postMessage(channel=CHANNEL,
                                     text=warning,
                                     thread_ts=response['ts'])
 
     for response_message in response_messages:
-        app.client.chat_postMessage(channel=TEAM_ART_CHANNEL,
+        app.client.chat_postMessage(channel=CHANNEL,
                                     text=response_message,
                                     thread_ts=response['ts'])  # use the timestamp from the response


### PR DESCRIPTION
1. Nofity when no unresolved ART threads are found, so we know the job didn't break and we're actually good
2. add mock param
3. make the notification channel parametric as well, to enable testing (defaults to `#team-art`)