### PR TITLE
Get a failed jobs notification periodically

### DIFF
--- a/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
+++ b/scheduled-jobs/scanning/unresolved-art-threads/Jenkinsfile
@@ -29,7 +29,9 @@ node() {
             withCredentials([
                                 string(credentialsId: "art-bot-slack-token", variable: "SLACK_API_TOKEN"),
                                 string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
-                                string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET")
+                                string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET"),
+                                string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                                string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')
                             ]) {
                 withEnv(["CHANNEL=${params.CHANNEL}"]) {
                     retry(10) {


### PR DESCRIPTION
This is to fetch job failures via jenkins api and post a message on the unresolved art threads 
thread in team slack channel. 

The motivation is to get a simple very visible place for release artists and team to notice the 
overall health of our jenkins jobs in slack.

Test notification: https://redhat-internal.slack.com/archives/C03U0TPBQMR/p1717512811407959?thread_ts=1717512811.239669&cid=C03U0TPBQMR

```
Failed aos-cd-jobs in last 3 hours:
{
  "build/build-sync": 6,
  "build/ocp4": 1,
  "build/ocp4_scan": 1,
  "build/olm_bundle": 1,
  "build/scan-for-kernel-bugs": 1
}
```