### PR TITLE
[poll-payload] different working dir to handle concurrent runs

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -72,7 +72,7 @@ def startBuildMicroshiftJob(String releaseStream, Map latestRelease, Map previou
     def x86_64_nightly = latestRelease.name
     // Get all nightlies matching the x86_64 nightly
     echo "Get nightlies matching the x86_64 nightly ${x86_64_nightly}..."
-    def cmd = "doozer --assembly=stream --arches x86_64,aarch64 --group openshift-${buildVersion} --working-dir ./doozer-working get-nightlies --matching ${x86_64_nightly}"
+    def cmd = "doozer --assembly=stream --arches x86_64,aarch64 --group openshift-${buildVersion} get-nightlies --matching ${x86_64_nightly}"
     def res = commonlib.shell(script: cmd, returnAll: true)
     if (res.returnStatus != 0) {
         if (res.combined.contains("Found no nightlies") || res.combined.contains("No sets of equivalent nightlies")) {


### PR DESCRIPTION
We seem to be running multiple doozer commands in parallel with the same working-dir where they are trying to clean and repopulate.

Dropping `--working-dir`, which will use a random dir in /tmp for every run




