### PR TITLE
Prune publish-rpms targets

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -21,14 +21,14 @@ import groovy.json.JsonOutput
     "4.17.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
     "4.17.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
 
-    "4.16.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
-    "4.16.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.16.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
+    "4.16.0-0.nightly-arm64": [this.&publishRPMsEl9],
 
-    "4.15.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
-    "4.15.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.15.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
+    "4.15.0-0.nightly-arm64": [this.&publishRPMsEl9],
 
-    "4.14.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
-    "4.14.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.14.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
+    "4.14.0-0.nightly-arm64": [this.&publishRPMsEl9],
 ]
 
 def setDevPreviewLatest(String releaseStream, Map latestRelease, Map previousRelease) {


### PR DESCRIPTION
Removing some rhel8 targets from publish-rpms. Customer microshift does not need it. BYO RHEL needs it only (I think!) for pre-GA versions. Proposing a prune and see who or what complains.