### PR TITLE
use build-in label for build-sync and olm_bundle

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('covscan') {
+node() {
 
     checkout scm
     def buildlib = load("pipeline-scripts/buildlib.groovy")

--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -1,4 +1,4 @@
-node('covscan') {
+node() {
     checkout scm
     def buildlib = load('pipeline-scripts/buildlib.groovy')
     def commonlib = buildlib.commonlib


### PR DESCRIPTION
the covscan label seems unnecessary and misleading