### PR TITLE
Link failed builds in job failure message

### DIFF
--- a/scheduled-jobs/scanning/art-notify/art-notify.py
+++ b/scheduled-jobs/scanning/art-notify/art-notify.py
@@ -67,7 +67,7 @@ def get_failed_jobs_text():
             text = f"* {link}: {len(failed_job_ids)} "
             failed_job_ids.sort(reverse=True)
             for i in range(min(3, len(failed_job_ids))):
-                text += f"[{job_link(job_name, failed_job_ids[i])}] "
+                text += f"[{job_link(job_name, job_id=failed_job_ids[i], text=i)}] "
             failed_jobs_list.append(text)
         failed_jobs_list = "\n".join(failed_jobs_list)
         failed_jobs_text = f"Failed aos-cd-jobs in last 3 hours: \n{failed_jobs_list}"

--- a/scheduled-jobs/scanning/art-notify/art-notify.py
+++ b/scheduled-jobs/scanning/art-notify/art-notify.py
@@ -67,7 +67,7 @@ def get_failed_jobs_text():
             text = f"* {link}: {len(failed_job_ids)} "
             failed_job_ids.sort(reverse=True)
             for i in range(min(3, len(failed_job_ids))):
-                text += f"[{job_link(job_name, job_id=failed_job_ids[i], text=i)}] "
+                text += f"[{job_link(job_name, job_id=failed_job_ids[i], text=i+1)}] "
             failed_jobs_list.append(text)
         failed_jobs_list = "\n".join(failed_jobs_list)
         failed_jobs_text = f"Failed aos-cd-jobs in last 3 hours: \n{failed_jobs_list}"


### PR DESCRIPTION
Link the top 3 failed builds in job failure notification message.
This makes triaging easier and immediately going to the failed 
job console.