### PR TITLE
check-bugs: Mark job as failed when any of the command fails

### DIFF
--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -55,10 +55,7 @@ node {
 
         buildlib.withAppCiAsArtPublish() {
             withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
-                def returnStatus = sh(script: cmd.join(' '), returnStatus: true)
-                if (returnStatus != 0) {
-                    currentBuild.result = "UNSTABLE"
-                }
+                sh(script: cmd.join(' '), returnStdout: true)
             }
         }
     }


### PR DESCRIPTION
This is so that check-bugs failures are not ignored in automated
checks like the one running in art-notify slack threads. Having a job
be "unstable" isn't a good indicator of failure, as how we do it in other
jobs. So make it consistent.