### PR TITLE
ART-10048: Enable microshift nightly build and publish-rpms job

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -18,6 +18,9 @@ import groovy.json.JsonOutput
     "4-dev-preview-ppc64le": [this.&setDevPreviewLatest],
     "4-dev-preview-arm64": [this.&setDevPreviewLatest],
 
+    "4.18.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.18.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+
     "4.17.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
     "4.17.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
 


### PR DESCRIPTION
once the branch cut for 4.18 was done this PR can be merged.
Until then it will be put on hold.