### PR TITLE
ROX-17632: Add OpenAPI spec synchronization to mirror.openshift.com/pub/rhacs

### DIFF
--- a/scheduled-jobs/build/sync-rhacs/Jenkinsfile
+++ b/scheduled-jobs/build/sync-rhacs/Jenkinsfile
@@ -35,11 +35,13 @@ node() {
                     set -e
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/assets/ s3://art-srv-enterprise/pub/rhacs/assets/
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/charts/ s3://art-srv-enterprise/pub/rhacs/charts/
+                    aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/openapi-spec/ s3://art-srv-enterprise/pub/rhacs/openapi-spec/
                     aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "/pub/rhacs/*"
 
-                    # Invalidation can be skipped for CLoudflare
+                    # Invalidation can be skipped for Cloudflare
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/assets/ s3://art-srv-enterprise/pub/rhacs/assets/ --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}
                     aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/charts/ s3://art-srv-enterprise/pub/rhacs/charts/ --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}
+                    aws s3 sync --no-progress --exact-timestamps --delete ${LOCAL_SYNC_DIR}/openapi-spec/ s3://art-srv-enterprise/pub/rhacs/openapi-spec/ --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}
                 """
             )
         }


### PR DESCRIPTION
We want to publish our OpenAPI spec (swagger.json) to mirror.openshift.com for customers to access and download. 

https://github.com/stackrox/stackrox/pull/12383 copies the file to the `gs://rhacs-openshift-mirror-src` bucket. 