### PR TITLE
Use rsync to clean up artcd_working

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -146,7 +146,7 @@ node() {
     }
 
     stage ("build sync") {
-        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        buildlib.init_artcd_working_dir()
         def cmd = [
             "artcd",
             "-v",

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -39,7 +39,7 @@ node {
 
     // Check bugs
     stage('check-bugs') {
-        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        buildlib.init_artcd_working_dir()
         def cmd = [
             "artcd",
             "-v",

--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -44,7 +44,7 @@ node {
     }
 
     advisory_list = commonlib.parseList(params.ADVISORIES)
-    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+    buildlib.init_artcd_working_dir()
 
     for(adv in advisory_list) {
         def cmd = [

--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -76,7 +76,7 @@ node {
             withEnv(["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
                 script {
                     // Prepare working dir
-                    sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                    buildlib.init_artcd_working_dir()
 
                     // Create artcd command
                     def cmd = [

--- a/jobs/build/k_ocp4/Jenkinsfile
+++ b/jobs/build/k_ocp4/Jenkinsfile
@@ -134,7 +134,7 @@ node {
                             usernamePassword(credentialsId: 'art-dash-db-login', passwordVariable: 'DOOZER_DB_PASSWORD', usernameVariable: 'DOOZER_DB_USER'),
                         ]) {
                     withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
-                        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                        buildlib.init_artcd_working_dir()
                         sh(script: cmd.join(' '), returnStdout: true)
                     }
                 }

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -225,7 +225,7 @@ node {
                                 file(credentialsId: "art-cluster-art-cd-pipeline-kubeconfig", variable: 'ART_CLUSTER_ART_CD_PIPELINE_KUBECONFIG'),
                             ]) {
                         withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
-                            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                            buildlib.init_artcd_working_dir()
                             sh(script: cmd.join(' '), returnStdout: true)
                         }
                     }

--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -87,7 +87,7 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
 
         stage("Scan") {
             sshagent(["openshift-bot"]) {
-                sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+                buildlib.init_artcd_working_dir()
                 cmd = [
                     "artcd",
                     "-vv",

--- a/jobs/build/olm_bundle/Jenkinsfile
+++ b/jobs/build/olm_bundle/Jenkinsfile
@@ -111,7 +111,7 @@ node() {
     stage('Build bundles') {
         script {
             // Prepare working dirs
-            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+            buildlib.init_artcd_working_dir()
             def doozer_working = "${WORKSPACE}/doozer_working"
             buildlib.cleanWorkdir(doozer_working)
 

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -47,7 +47,7 @@ node {
     ])
     stage('operator-sdk-sync') {
         script {
-            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+            buildlib.init_artcd_working_dir()
             currentBuild.displayName += " ${params.ASSEMBLY}"
             def cmd = [
                 "artcd",

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -128,7 +128,7 @@ node {
     def release_info = [:]
 
     stage("promote release") {
-        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        buildlib.init_artcd_working_dir()
         def cmd = [
             "artcd",
             "-v",

--- a/jobs/build/rebuild-golang-rpms/Jenkinsfile
+++ b/jobs/build/rebuild-golang-rpms/Jenkinsfile
@@ -71,7 +71,7 @@ node {
 
         script {
             // Prepare working dir
-            sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+            buildlib.init_artcd_working_dir()
 
             // Create artcd command
             def cmd = [

--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -86,7 +86,8 @@ node {
                 currentBuild.displayName += "multi"
                 echo "triggering multi builds"
                 def jenkins_url = 'https://jenkins-rhcos.apps.ocp-virt.prod.psi.redhat.com'
-                commonlib.shell(script: "pip install -e ./art-tools/pyartcd && rm -rf ./artcd_working && mkdir -p ./artcd_working")
+                commonlib.shell(script: "pip install -e ./art-tools/pyartcd")
+                buildlib.init_artcd_working_dir()
 
                 def dryrun = params.DRY_RUN ? '--dry-run' : ''
                 def run_multi_build = {

--- a/jobs/build/tarball-sources/Jenkinsfile
+++ b/jobs/build/tarball-sources/Jenkinsfile
@@ -72,8 +72,8 @@ node {
             def output = ""
 
             stage("run tarball-sources") {
-                sh "rm -rf ./artcd_working"
-                sh "mkdir -p ./artcd_working"
+                buildlib.init_artcd_working_dir()
+                
                 def cmd = [
                     "artcd",
                     "-v",

--- a/jobs/maintenance/cleanup-locks/Jenkinsfile
+++ b/jobs/maintenance/cleanup-locks/Jenkinsfile
@@ -32,7 +32,7 @@ node {
 
     // Clean up locks
     stage('cleanup-locks') {
-        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        buildlib.init_artcd_working_dir()
         def cmd = [
             "artcd",
             "-v",

--- a/jobs/signing/sigstore-sign/Jenkinsfile
+++ b/jobs/signing/sigstore-sign/Jenkinsfile
@@ -64,7 +64,7 @@ node {
     stage("initialize") {
         // must be able to access and update quay registry
         buildlib.registry_quay_dev_login()
-        sh "rm -rf ./artcd_working && mkdir -p ./artcd_working"
+        buildlib.init_artcd_working_dir()
     }
 
     stage("sign") {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -125,6 +125,18 @@ def initialize_openshift_dir() {
     echo "Initialized env.OPENSHIFT_DIR: ${env.OPENSHIFT_DIR}"
 }
 
+def init_artcd_working_dir() {
+    // Removing folders that contain a lot of files can be time consuming.
+    // Using rsync is a more performant alternative: https://unix.stackexchange.com/a/79656
+
+    sh """
+    mkdir /tmp/empty
+    rsync -a --delete /tmp/empty ./artcd_working
+    rmdir /tmp/empty ./artcd_working
+    mkdir -p ./artcd_working
+    """
+}
+
 def cleanWhitespace(cmd) {
     return (cmd
         .replaceAll( ' *\\\n *', ' ' ) // If caller included line continuation characters, remove them


### PR DESCRIPTION
I randomly noticed that a few ocp4 builds were stuck for a while on `rm -rf ./artcd_working`. Using `rsync` instead should make the operation quicker.

Test build: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/dpaolell/job/ocp4/2/console