### PR TITLE
Do not fail on mkdir if /tmp/empty already exists

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -131,9 +131,9 @@ def init_artcd_working_dir() {
 
     sh """
     if [ -d "./artcd_working" ]; then
-        mkdir /tmp/empty
-        rsync -a --delete /tmp/empty/ ./artcd_working/
-        rmdir /tmp/empty ./artcd_working
+        mkdir -p ./empty
+        rsync -a --delete ./empty/ ./artcd_working/
+        rmdir ./empty ./artcd_working
     fi
     mkdir -p ./artcd_working
     """


### PR DESCRIPTION
To prevent errors like
```
mkdir: cannot create directory ‘/tmp/empty’: File exists
```
as seen [here](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4_scan/63383/console)