### PR TITLE
set client latest: Remove 4.11 specific code paths

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -89,15 +89,9 @@ for arch in ${ARCHES}; do
             x86_64) qarch="amd64" ;;
             aarch64) qarch="arm64" ;;
         esac
-        if [[ "$arch" == "multi" && "${USE_CHANNEL}" == "fast-4.11" && "${LINK_NAME}" == "latest" ]]; then
-            # 4.11 multi releases have "-multi" in their names, which are not in Cincinnati graph.
-            # query amd64 arch instead.
-            qarch=amd64
-        fi
         CHANNEL_RELEASES=$(
             curl -sH "Accept:application/json" "https://api.openshift.com/api/upgrades_info/v1/graph?channel=${USE_CHANNEL}&arch=${qarch}" |
-              jq '.nodes[].version' -r |
-              { grep -vFx 4.11.2 || true; }
+              jq '.nodes[].version' -r
         )
         if [[ -z "$CHANNEL_RELEASES" ]]; then
             echo "No versions currently detected in ${USE_CHANNEL} for arch ${qarch} ; No ${LINK_NAME} will be set"
@@ -113,18 +107,6 @@ for arch in ${ARCHES}; do
         if [[ ${RELEASE} != ${MAJOR_MINOR}* ]]; then
             echo "${RELEASE} is latest in ${USE_CHANNEL}, but appears to be from previous release; ignoring"
             continue
-        fi
-
-        if [[ "$arch" == "multi" && "${USE_CHANNEL}" == "fast-4.11" && "${LINK_NAME}" == "latest" ]]; then
-            # Because we use the amd64 graph data, we need to check if multi client binaries are already published to mirror.
-            qrelease=$(RELEASE=$RELEASE python3 -c 'import os; from semver import VersionInfo; parsed_version = VersionInfo.parse(os.environ["RELEASE"]); parsed_version=parsed_version.replace(prerelease=f"multi-{parsed_version.prerelease}" if parsed_version.prerelease else "multi"); print(parsed_version)')
-            rc=0
-            curl --fail -o /dev/null "https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/$qrelease/sha256sum.txt.gpg" || rc=$?
-            if [[ $rc != 0 ]]; then
-                echo "${RELEASE} for multi arch is latest in ${USE_CHANNEL}, but client binaries are not published; ignoring"
-                continue
-            fi
-            RELEASE=$qrelease
         fi
     fi
 


### PR DESCRIPTION
Since 4.11 is EOL now, we can remove these 