### PR TITLE
ose-operator-registry move to rhel9

### DIFF
--- a/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
+++ b/scheduled-jobs/build/early-operator-index/Jenkinsfile.groovy
@@ -33,7 +33,7 @@ node {
     request = [
         'bundles': pullspecs.findAll { it != "None" },  // Ignore bundle if it has not been built yet
         'from_index': "registry-proxy.engineering.redhat.com/rh-osbs/iib-pub-pending:v${operatorIndexBaseVersion}",
-        'binary_image': "registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry:v${operatorRegistryVersion}.0"
+        'binary_image': "registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry-rhel9:v${operatorRegistryVersion}.0"
     ]
 
     writeJSON(file: 'request.json', json: request, pretty: 4)


### PR DESCRIPTION
fix early-operator-index job can't resolve ose-operator-registry pullspec