### PR TITLE
Stop 4.7 and 4.11

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -14,8 +14,6 @@ ocp4Versions = [
     "4.14",
     "4.13",
     "4.12",
-    "4.11",
-    "4.7",
 ]
 
 ocpVersions = ocp4Versions + ocp3Versions


### PR DESCRIPTION
If this would turn out to be needed, we can re-enable