### PR TITLE
ocp4-scan do not flake out on podman login

### DIFF
--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -69,7 +69,10 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
         )
 
         commonlib.checkMock()
-        buildlib.registry_quay_dev_login()
+
+        retry(3) {
+            buildlib.registry_quay_dev_login()
+        }
 
         stage("Initialize") {
             currentBuild.displayName = "#${currentBuild.number} ${params.VERSION}"


### PR DESCRIPTION
Seen [here](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4_scan/69154/console):
```
+ podman login -u **** -p **** quay.io
Error: authenticating creds for "quay.io": received unexpected HTTP status: 504 Gateway Time-out
```