### PR TITLE
update gen-assembly NIGHTLIES param help

### DIFF
--- a/jobs/build/gen-assembly/Jenkinsfile
+++ b/jobs/build/gen-assembly/Jenkinsfile
@@ -39,7 +39,7 @@ node {
                         ),
                         string(
                             name: "NIGHTLIES",
-                            description: "(Optional) List of nightlies to match with <code>doozer get-nightlies</code> (if empty, find latest)",
+                            description: "(Optional for public nightlies) List of nightlies to match with <code>doozer get-nightlies</code> (if empty, find latest). If preparing from private nightlies, provide the amd64 nightly as parameter, to match. The automation will find the corresponding nightlies for other arches.",
                             trim: true,
                         ),
                         booleanParam(


### PR DESCRIPTION
related to https://github.com/openshift-eng/art-tools/pull/925

the automation checks the presence of "priv" in the nightly name to figure out where to look (private / public release controller)