### PR TITLE
update disk partition path

### DIFF
--- a/jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
+++ b/jobs/maintenance/check-disk-usage-on-buildvm/Jenkinsfile
@@ -41,9 +41,8 @@ notify ART team if it does.
     commonlib.checkMock()
 
     partitions_to_check = [
-        "/dev/mapper/rhel_buildvm-root",
-        "/dev/mapper/workspace-workspace",
-        "infinibox01-bos-nfs.prod.psi.bos.redhat.com:/buildvm-openshift",
+        "/mnt/jenkins-home",
+        "/mnt/jenkins-workspace",
     ]
 
     warnings = []


### PR DESCRIPTION
update jenkins disk partition path
now new jenkins disk looks like
```
[jenkins@buildvm ~]$ df -h
Filesystem                                                                                                    Size  Used Avail Use% Mounted on
devtmpfs                                                                                                      4.0M     0  4.0M   0% /dev
tmpfs                                                                                                          32G   32M   32G   1% /dev/shm
tmpfs                                                                                                          13G  1.3G   12G  10% /run
/dev/vda4                                                                                                      64G   48G   16G  76% /
/dev/vda3                                                                                                     536M  385M  152M  72% /boot
/dev/vdc                                                                                                      196G  159G   28G  86% /mnt/jenkins-home
/dev/vdd                                                                                                      3.0T  1.5T  1.4T  51% /mnt/jenkins-workspace
/dev/vda2                                                                                                     200M  7.1M  193M   4% /boot/efi
tmpfs                                                                                                         6.3G   28K  6.3G   1% /run/user/984
ntap-iad2-c01-eng01-nfs01b.neta-002.prod.iad2.dc.redhat.com:/devops_engineering_nfs/devarchive/redhat          85T   81T  4.0T  96% /mnt/redhat
tmpfs                                                                                                         6.3G  4.0K  6.3G   1% /run/user/116407
ntap-iad2-c01-eng01-nfs01b.neta-002.prod.iad2.dc.redhat.com:/devops_engineering_nfs/devarchive/redhat/rhel-9   79T   67T   13T  85% /mnt/redhat/rhel-9
ntap-iad2-c01-eng01-nfs01b.neta-002.prod.iad2.dc.redhat.com:/devops_engineering_nfs/devarchive/redhat/rhel-8   82T   78T  4.3T  95% /mnt/redhat/rhel-8
tmpfs                                                                                                         6.3G  4.0K  6.3G   1% /run/user/109243
[jenkins@buildvm ~]$ df -h |grep "/mnt/jenkins-home" | tr -s ' ' | cut -d ' ' -f5 | tr -d %
86
```