### PR TITLE
limit logrotator to 15 days and clean workspace

### DIFF
--- a/jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -16,9 +16,9 @@ node {
                 disableResume(),
                 buildDiscarder(
                     logRotator(
-                        artifactDaysToKeepStr: "",
+                        artifactDaysToKeepStr: '15',
                         artifactNumToKeepStr: "",
-                        daysToKeepStr: "",
+                        daysToKeepStr: '15',
                         numToKeepStr: "")),
                 [
                     $class: "ParametersDefinitionProperty",

--- a/jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -92,13 +92,7 @@ node {
             currentBuild.result = "FAILURE"
             throw err
         } finally {
-            commonlib.safeArchiveArtifacts([
-                "artcd_working/email/**",
-                "artcd_working/**/*.json",
-                "artcd_working/**/*.log",
-                "artcd_working/**/*.yaml",
-                "artcd_working/**/*.yml",
-            ])
+            commonlib.safeArchiveArtifacts(["artcd_working/*.log"])
             buildlib.cleanWorkspace()
         }
     }


### PR DESCRIPTION
the scan-for-kernel-bugs job now take 15GB on buildvm because it store all history builds and save art-tools in artifacts for each job, this pr clean them to save some spaces