### PR TITLE
Dump versions at init

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -9,6 +9,13 @@ GITHUB_URLS = [:]
 GITHUB_BASE_PATHS = [:]
 GITHUB_BASE = "git@github.com:openshift"
 
+// dump important tool versions to console
+def dump_versions() {
+    sh "oc version --client"
+    this.doozer "--version"
+    this.elliott "--version"
+}
+
 def initialize(test=false, regAws=false) {
     def hostname = env['HOSTNAME']
 
@@ -19,6 +26,7 @@ def initialize(test=false, regAws=false) {
 
     this.setup_venv()
     this.path_setup()
+    this.dump_versions()
 
     // don't bother logging into a registry or getting a krb5 ticket for tests
     if (!test) {

--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -11,6 +11,7 @@ GITHUB_BASE = "git@github.com:openshift"
 
 // dump important tool versions to console
 def dump_versions() {
+    sh "ls -l $(which oc)"
     sh "oc version --client"
     this.doozer "--version"
     this.elliott "--version"


### PR DESCRIPTION
Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fcheck-bugs/176/console

This is so that we know which version of oc binary is used in a job run