### PR TITLE
escape dollar

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -11,7 +11,7 @@ GITHUB_BASE = "git@github.com:openshift"
 
 // dump important tool versions to console
 def dump_versions() {
-    sh "ls -l $(which oc)"
+    sh "ls -l \$(which oc)"
     sh "oc version --client"
     this.doozer "--version"
     this.elliott "--version"


### PR DESCRIPTION
```
Script1.groovy: 14: illegal string body character after dollar sign;
   solution: either escape a literal dollar sign "\$5" or bracket the value expression "${5}" @ line 14, column 5.
       sh "ls -l $(which oc)"
```