### PR TITLE
Better build user filtering

### DIFF
--- a/scheduled-jobs/scanning/art-notify/art-notify.py
+++ b/scheduled-jobs/scanning/art-notify/art-notify.py
@@ -57,7 +57,8 @@ def get_failed_jobs_text():
                 # would be monitored by whoever triggered them
                 # Builds which are triggered by another build will not have userId
                 # so we include them by default
-                user_id = next(a['causes'][0].get('userId') for a in build.get('actions') if a.get('causes'))
+                user_id = next((cause.get('userId') for action in build.get('actions', [])
+                                for cause in action.get('causes', [])), None)
                 if user_id and user_id != ART_BOT_JENKINS_USERID:
                     continue
                 total_eligible_builds += 1


### PR DESCRIPTION
Right now we only look at first element of cause array to fetch user_id, 
which is not always true. 

Example `actions` output
```
[
  {'_class': 'hudson.model.CauseAction', 'causes': [
    {'_class': 'org.jenkinsci.plugins.workflow.cps.replay.ReplayCause'}, 
    {'_class': 'hudson.model.Cause$UserIdCause', 'userId': 'dpaolell'}, 
    {'_class': 'com.sonyericsson.rebuild.RebuildCause'}]}, 
... 
]
```