### PR TITLE
Fix s3 mirror sync dry-run

### DIFF
--- a/jobs/build/microshift_sync/Jenkinsfile
+++ b/jobs/build/microshift_sync/Jenkinsfile
@@ -159,9 +159,9 @@ node {
                     def mirror_path = "/pub/openshift-v4/${arch}/microshift/${client_type}/${release_name}/${repo_name}/os"
                     def latest_path = "/pub/openshift-v4/${arch}/microshift/${client_type}/latest-${version}/${repo_name}/os"
                     withEnv(["https_proxy="]) {
-                        commonlib.syncRepoToS3Mirror(mirror_src, mirror_path, true, 10, dry_run)
+                        commonlib.syncRepoToS3Mirror(mirror_src, mirror_path, true, 10, true, dry_run)
                         if (set_latest) {
-                            commonlib.syncRepoToS3Mirror(mirror_src, latest_path, true, 10, dry_run)
+                            commonlib.syncRepoToS3Mirror(mirror_src, latest_path, true, 10, true, dry_run)
                         }
                     }
                 }


### PR DESCRIPTION
We have a bug where microshift_sync misses passing dry_run param.

Also add dry_run to cache invalidation func.

https://docs.aws.amazon.com/cli/latest/reference/cloudfront/create-invalidation.html doesn't detail a dryrun,
so instead just print the cmd.