### PR TITLE
ART-10946 - Upload rhcos-id.txt

### DIFF
--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -80,11 +80,6 @@ node {
                         description: 'Do not update the <b>latest</b> symlink after downloading',
                         defaultValue: false,
                     ),
-                    booleanParam(
-                        name: 'NO_MIRROR',
-                        description: 'Do not run the push.pub script after downloading',
-                        defaultValue: false,
-                    ),
                     commonlib.suppressEmailParam(),
                     commonlib.dryrunParam(),
                     commonlib.mockParam(),

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -162,17 +162,6 @@ node {
         *:heavy_exclamation_mark: rhcos_sync ${mirrorPrefix} failed*
         buildvm job: ${commonlib.buildURL('console')}
         """)
-        commonlib.email(
-            to: "aos-art-automation+failed-rhcos-sync@redhat.com",
-            from: "aos-art-automation@redhat.com",
-            replyTo: "aos-team-art@redhat.com",
-            subject: "Error during OCP ${mirrorPrefix} build sync",
-            body: """
-There was an issue running build-sync for OCP ${mirrorPrefix}:
-
-    ${err}
-""")
-        throw ( err )
     } finally {
         commonlib.safeArchiveArtifacts(rhcoslib.artifacts)
         buildlib.cleanWorkspace()

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -36,51 +36,21 @@ node {
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     string(
-                        name: 'FROM_RELEASE_TAG',
-                        description: 'Release Name (or pullspec with a tag) from which to get RHCOS buildID reference (ex. 4.12.0-ec.2-x86_64). <b>Note:</b> The buildID is pulled from the installer image in the payload, which is often different from what is in the rhcos image - so make sure the installer image points to the right buildID OR use OVERRIDE_BUILD.',
-                        defaultValue: "",
-                        trim: true,
-                    ),
-                    commonlib.ocpVersionParam('OCP_VERSION', '4', ['auto']),
-                    string(
-                        name: 'OVERRIDE_BUILD',
-                        description: "ID of the RHCOS build to sync. e.g.: <code>42.80.20190828.2</code>. Empty (default) will retrieve the metadata from the installer image. <b>Leave empty, unless you know what you're doing</b>",
-                        defaultValue: "",
-                        trim: true,
-                    ),
-                    choice(
-                        name: 'ARCH',
-                        description: 'Which architecture of RHCOS build to look for. Required with <code>OVERRIDE_BUILD</code>. Leave at <code>auto</code> otherwise.',
-                        choices: (["auto"] + commonlib.brewArches),
-                    ),
-                    string(
-                        name: 'OVERRIDE_NAME',
-                        description: 'The release name, like <b>4.2.0</b>, or <b>4.2.0-0.nightly-2019-08-28-152644</b>. Required with <code>OVERRIDE_BUILD</code>. Leave at empty otherwise.',
-                        defaultValue: "",
-                        trim: true,
-                    ),
-                    choice(
-                        name: 'MIRROR_PREFIX',
-                        description: 'Where to place this release under <b><code>https://mirror.openshift.com/pub/openshift-v4/ARCH/dependencies/rhcos/<code></b>. Auto sets to image version for stable releases (example if <code>FROM_RELEASE_TAG</code> is <b>4.8.4-x86_64</b> then directory is <b>4.8</b>), <b>pre-release</b> for all other <code>FROM_RELEASE_TAG</code> values. <b>auto</b> cannot be used with <code>OVERRIDE_BUILD</code>',
-                        choices: (['auto' ,'pre-release', 'test'] + commonlib.ocp4Versions),
-                    ),
-                    string(
-                        name: 'SYNC_LIST',
-                        description: 'Instead of figuring out items to sync from meta.json, use this input file.<br>Must be a URL reachable from buildvm.<br>If name ends in ".json" then read it like meta.json, otherwise content should be line-separated filenames.',
+                        name: 'RELEASE_TAG',
+                        description: 'Release Name (or pullspec with a tag) from which to get RHCOS buildID reference (ex. 4.12.0-ec.2-x86_64). <b>Note:</b> The buildID is pulled from the installer image in the payload, which is often different from what is in the rhcos image - so make sure the installer image points to the right buildID.',
                         defaultValue: "",
                         trim: true,
                     ),
                     booleanParam(
                         name: 'FORCE',
-                        description: 'Download (overwrite) and mirror items even if the destination directory already exists<br>Erases everything already in the target destination.',
+                        description: 'Download and sync items even if it is deemed unnecessary',
                         defaultValue: false,
                     ),
                     booleanParam(
                         name: 'NO_LATEST',
-                        description: 'Do not update the <b>latest</b> symlink after downloading',
+                        description: 'Do not update the <b>latest</b> directory',
                         defaultValue: false,
                     ),
-                    commonlib.suppressEmailParam(),
                     commonlib.dryrunParam(),
                     commonlib.mockParam(),
                 ],
@@ -90,70 +60,44 @@ node {
 
     commonlib.checkMock()
 
-    if (params.OVERRIDE_BUILD != "") {
-        if (params.OVERRIDE_NAME == "") {
-            error("Need a valid OVERRIDE_NAME value")
-        }
-        if (params.ARCH == "auto") {
-            error("ARCH cannot be auto, need to be explicit")
-        }
-        if (params.MIRROR_PREFIX == "auto") {
-            error("MIRROR_PREFIX cannot be auto, need to be explicit")
-        }
-        if (params.OCP_VERSION == "auto") {
-            error("OCP_VERSION cannot be auto, need to be explicit")
-        }
-        ocpVersion = params.OCP_VERSION
-        rhcosBuild = params.OVERRIDE_BUILD
-        arch = params.ARCH
-        name = params.OVERRIDE_NAME
-    } else {
-        if (!params.FROM_RELEASE_TAG) {
-            error("Need FROM_RELEASE_TAG")
-        }
-
-        tag = params.FROM_RELEASE_TAG
-        image = "quay.io/openshift-release-dev/ocp-release:${tag}"
-        if (tag.contains("/")) {
-            // assume instead of a tag it's a pullspec e.g. to registry.ci
-            if (!tag.contains(":")) error("FROM_RELEASE_TAG pullspec must include a :tag")
-            image = tag
-            tag = tag.split(":")[-1]
-        }
-
-        if (params.OVERRIDE_NAME != "")
-            name = params.OVERRIDE_NAME
-        else
-            name = commonlib.shell(
-                returnStdout: true,
-                script: "oc adm release info -o template --template '{{ .metadata.version }}' ${image}"
-            )
-
-        (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
-        ocpVersion = "$major.$minor"
-
-        (arch, priv) = releaselib.getReleaseTagArchPriv(tag)
-        suffix = releaselib.getArchPrivSuffix(arch, priv)
-
-        cmd = """
-            tmp=\$(mktemp -d /tmp/tmp.XXXXXX)
-            oc image extract --path /manifests/:\$tmp \$(oc adm release info --image-for installer ${image})
-            cat \$tmp/coreos-bootimages.yaml | yq -r .data.stream | jq -r .architectures.${arch}.artifacts.qemu.release
-            rm -rf \$tmp
-        """
-        rhcosBuild =  commonlib.shell(
-            returnStdout: true,
-            script: cmd
-        ).trim()
+    if (!params.RELEASE_TAG) {
+        error("Need RELEASE_TAG")
     }
 
-    if (params.MIRROR_PREFIX == 'auto') {
-        pattern = /$major\.$minor\.(\d+)-$arch/
-        is_stable = tag ==~ pattern
-        mirrorPrefix = is_stable ? ocpVersion : "pre-release"
-    } else {
-        mirrorPrefix = params.MIRROR_PREFIX
+    tag = params.RELEASE_TAG
+    image = "quay.io/openshift-release-dev/ocp-release:${tag}"
+    if (tag.contains("/")) {
+        // assume instead of a tag it's a pullspec e.g. to registry.ci
+        if (!tag.contains(":")) error("RELEASE_TAG pullspec must include a :tag")
+        image = tag
+        tag = tag.split(":")[-1]
     }
+
+    name = commonlib.shell(
+        returnStdout: true,
+        script: "oc adm release info -o template --template '{{ .metadata.version }}' ${image}"
+    )
+
+    (major, minor) = commonlib.extractMajorMinorVersionNumbers(tag)
+    ocpVersion = "$major.$minor"
+
+    (arch, priv) = releaselib.getReleaseTagArchPriv(tag)
+    suffix = releaselib.getArchPrivSuffix(arch, priv)
+
+    cmd = """
+        tmp=\$(mktemp -d /tmp/tmp.XXXXXX)
+        oc image extract --path /manifests/:\$tmp \$(oc adm release info --image-for installer ${image})
+        cat \$tmp/coreos-bootimages.yaml | yq -r .data.stream | jq -r .architectures.${arch}.artifacts.qemu.release
+        rm -rf \$tmp
+    """
+    rhcosBuild =  commonlib.shell(
+        returnStdout: true,
+        script: cmd
+    ).trim()
+
+    pattern = /$major\.$minor\.(\d+)-$arch/
+    is_stable = tag ==~ pattern
+    mirrorPrefix = is_stable ? ocpVersion : "pre-release"
 
     print("RHCOS build: $rhcosBuild, arch: $arch, mirror prefix: $mirrorPrefix")
 
@@ -162,15 +106,11 @@ node {
 
     try {
         stage("Get/Generate sync list") {
-            if ( params.SYNC_LIST == "" || params.SYNC_LIST.endsWith(".json") )
-                rhcoslib.rhcosSyncPrintArtifacts()
-            else
-                rhcoslib.rhcosSyncManualInput()
+            rhcoslib.rhcosSyncPrintArtifacts()
         }
         stage("Mirror artifacts") {
             rhcoslib.rhcosSyncMirrorArtifacts(mirrorPrefix, arch, rhcosBuild, name)
         }
-        // stage("Gen AMI docs") { build.rhcosSyncGenDocs(rhcosBuild) }
         stage("Slack notification to release channel") {
             slacklib.to(ocpVersion).say("""
             *:white_check_mark: rhcos_sync (${mirrorPrefix}) successful*
@@ -182,7 +122,7 @@ node {
 
         // only run for x86_64 since no AMIs for other arches
         // only sync AMI to ROSA Marketplace account when no custom sync list is defined
-        if ( params.SYNC_LIST == "" && arch == "x86_64") {
+        if ( arch == "x86_64") {
             stage("Mirror ROSA AMIs") {
                 if ( arch != 'x86_64' ) {
                     echo "Skipping ROSA sync for non-x86 arch"

--- a/jobs/build/rhcos_sync/S3-rhcossync.sh
+++ b/jobs/build/rhcos_sync/S3-rhcossync.sh
@@ -175,7 +175,7 @@ downloadImages
 genSha256
 genRhcosIdTxt
 
-if [ $TEST -eq 1 -o $NOMIRROR -eq 1 ]; then
+if [ $TEST -eq 1 ]; then
   echo Would have copied out to ${BASEDIR}/${RHCOS_MIRROR_PREFIX}/${VERSION}/:
   ls
   exit 0

--- a/jobs/build/rhcos_sync/S3-rhcossync.sh
+++ b/jobs/build/rhcos_sync/S3-rhcossync.sh
@@ -8,11 +8,9 @@ ARCH=x86_64
 BUILDID=
 # release version, like 4.2.0:
 VERSION=
-FORCE=0
 TEST=0
 BASEDIR=
 NOLATEST=0
-NOMIRROR=0
 
 function usage() {
     cat <<EOF
@@ -34,7 +32,6 @@ Optional Options:
 
   --nolatest       Do not update the 'latest' symlink after downloading
   --test           Test inputs, but ensure nothing can ever go out to the mirrors
-  --nomirror       Do not run the push.pub script after downloading
 
 
 EOF
@@ -64,9 +61,13 @@ function downloadImages() {
 }
 
 function genSha256() {
-    sha256sum * > sha256sum.txt
+    sha256sum *[!rhcos-id.txt] > sha256sum.txt
     ls -lh
     cat sha256sum.txt
+}
+
+function genRhcosIdTxt() {
+    echo ${BUILDID} > rhcos-id.txt
 }
 
 function emulateSymlinks() {
@@ -148,10 +149,6 @@ while [ $1 ]; do
         NOLATEST=1;;
     "--test")
         TEST=1;;
-    "--nomirror")
-        NOMIRROR=1;;
-    "--force")
-        FORCE=1;;
     "-h" | "--help")
         usage
         exit 0;;
@@ -176,6 +173,7 @@ EOF
 pushd $DESTDIR
 downloadImages
 genSha256
+genRhcosIdTxt
 
 if [ $TEST -eq 1 -o $NOMIRROR -eq 1 ]; then
   echo Would have copied out to ${BASEDIR}/${RHCOS_MIRROR_PREFIX}/${VERSION}/:

--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -90,17 +90,11 @@ def rhcosSyncMirrorArtifacts(rhcosMirrorPrefix, arch, rhcosBuild, name) {
         " --buildid ${rhcosBuild}" +
         " --version ${name}"
 
-    if ( params.FORCE ) {
-            invokeOpts += " --force"
-    }
     if ( params.DRY_RUN ) {
             invokeOpts += " --test"
     }
     if ( params.NO_LATEST ) {
             invokeOpts += " --nolatest"
-    }
-    if ( params.NO_MIRROR ) {
-            invokeOpts += " --nomirror"
     }
 
     withCredentials([

--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -56,17 +56,10 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     }
 
     dir ( rhcosWorking ) {
-        if ( params.SYNC_LIST == "" || params.SYNC_LIST.endsWith(".json") ) {
-            sh("wget ${params.SYNC_LIST ?: metaUrl} -O meta.json")
-            artifacts.add("${rhcosWorking}/meta.json")
-        }
-
+        sh("wget ${metaUrl} -O meta.json")
+        artifacts.add("${rhcosWorking}/meta.json")
         commonlib.shell(script: "pip install awscli")
     }
-}
-
-def rhcosSyncManualInput() {
-    sh("wget ${params.SYNC_LIST} -O ${syncList}")
 }
 
 def rhcosSyncPrintArtifacts() {
@@ -107,14 +100,5 @@ def rhcosSyncMirrorArtifacts(rhcosMirrorPrefix, arch, rhcosBuild, name) {
 def rhcosSyncROSA() {
     commonlib.shell("${env.WORKSPACE}/build-scripts/rosa-sync/rosa_sync.sh ${rhcosWorking}/meta.json ${params.DRY_RUN}")
 }
-
-def rhcosSyncGenDocs(rhcosBuild) {
-    dir( rhcosWorking ) {
-        // TODO
-        // sh("sh ../gen-docs.sh < meta.json > rhcos-${rhcosBuild}.adoc")
-    }
-    artifacts.add("${rhcosWorking}/rhcos-${rhcosBuild}.adoc")
-}
-
 
 return this


### PR DESCRIPTION
As part of [ART-10946](https://issues.redhat.com//browse/ART-10946), upload rhcos-id.txt.
To prepare for the job logic to migrate from groovy to artcd/python, remove
flags that we keep for flexibility but very rarely use. If there is a need, we will
re-introduce them in artcd script according to requirements.

Should go with https://github.com/openshift-eng/art-tools/pull/1119

Test run: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/sidsharm-aos-cd-jobs/job/build%252Frhcos_sync/4