### PR TITLE
Add scheduled job for ocp4-scan-konflux

### DIFF
--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile
@@ -1,0 +1,57 @@
+node {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+    slacklib = commonlib.slacklib
+
+    properties( [
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+        disableConcurrentBuilds(),
+        disableResume(),
+        [
+            $class: "ParametersDefinitionProperty",
+            parameterDefinitions: [
+                commonlib.artToolsParam(),
+                commonlib.mockParam(),
+            ]
+        ]
+    ] )
+
+    commonlib.checkMock()
+    buildlib.init_artcd_working_dir()
+
+    stage("scan") {
+        cmd = [
+            "artcd",
+            "-vv",
+            "--working-dir=${WORKSPACE}/artcd_working",
+            "--config=./config/artcd.toml",
+            "schedule-ocp4-scan-konflux",
+            "--version=4.18"  // to be removed once we have full capacity
+        ]
+        // Uncomment following lines to scan all arches (to be done once we have full capacity)
+        //for ( version in commonlib.ocp4Versions ) {
+        //    cmd << "--version=${version}"
+        //}
+
+        withCredentials([
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD')]) {
+            wrap([$class: 'BuildUser']) {
+                builderEmail = env.BUILD_USER_EMAIL
+            }
+
+            withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
+                try {
+                    echo "Will run ${cmd}"
+                    sh(script: cmd.join(' '), returnStdout: true)
+                } catch (err) {
+                    slacklib.to("#art-release").failure("Error running ocp_scan", err)
+                    throw err
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Schedule ocp4-scan for Konflux. At the moment, we're limiting the scan to 4.18, to be unblocked once we are at full capacity.