### PR TITLE
[konflux] add redis-server-password

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -130,6 +130,7 @@ node {
                 withCredentials([
                             file(credentialsId: 'openshift-bot-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                            string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS')
                 ]){
                     withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {


### PR DESCRIPTION
```
artcommonlib.redis.RedisError: Please define REDIS_SERVER_PASSWORD env var
sys:1: RuntimeWarning: coroutine 'KonfluxOcp4Pipeline.run' was never awaited
```

related to https://github.com/openshift-eng/art-tools/pull/1122