### PR TITLE
Do not include 9.5 rhel builds

### DIFF
--- a/jobs/build/publish-rpms/collect_deps.py
+++ b/jobs/build/publish-rpms/collect_deps.py
@@ -139,15 +139,18 @@ async def download_rpms(ocp_version: str, arch: str, rhel_major: int, output_dir
             "download",
             f"--releasever={rhel_major}",
             "-c", f"{yum_conf_filename}",
-            "--resolve",
             "--disableplugin=subscription-manager",
             "--downloadonly",
-            "--alldeps",
             #f"--installroot={Path(install_root_dir).absolute()}",
             f"--destdir={output_dir}",
             f"--forcearch={arch}",
-            "--",
-        ] + packages
+        ]
+        if rhel_major == 8:
+            cmd.extend(['--resolve', '--alldeps'])
+
+        cmd.append('--')
+        cmd.extend(packages)
+
         LOGGER.info("Running command %s", cmd)
         env = os.environ.copy()
         # yum doesn't honor cachedir in the yum.conf. It keeps a user specific cache


### PR DESCRIPTION
Since rhel9.5 shipped, rhel9.5 packages got included in the beta repository. This is not helpful, as the context is really 9.4. We cannot just move to the rhel9.4 repository, as we would be making els content publicly available.

This change proposes to:
- Not touch rhel8 beta repositories
- Change rhel9 beta repositories to only include what is needed, and leave it to the consumer to find the matching rhel bits.