### PR TITLE
Adjust poll-payload actions

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -18,20 +18,19 @@ import groovy.json.JsonOutput
     "4-dev-preview-ppc64le": [this.&setDevPreviewLatest],
     "4-dev-preview-arm64": [this.&setDevPreviewLatest],
 
+    "4.19.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.19.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+
     "4.18.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
     "4.18.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
 
-    "4.17.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8],
-    "4.17.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+    "4.17.0-0.nightly":  [this.&startBuildMicroshiftJob],
 
-    "4.16.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
-    "4.16.0-0.nightly-arm64": [this.&publishRPMsEl9],
+    "4.16.0-0.nightly":  [this.&startBuildMicroshiftJob],
 
-    "4.15.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
-    "4.15.0-0.nightly-arm64": [this.&publishRPMsEl9],
+    "4.15.0-0.nightly":  [this.&startBuildMicroshiftJob],
 
-    "4.14.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9],
-    "4.14.0-0.nightly-arm64": [this.&publishRPMsEl9],
+    "4.14.0-0.nightly":  [this.&startBuildMicroshiftJob],
 ]
 
 def setDevPreviewLatest(String releaseStream, Map latestRelease, Map previousRelease) {


### PR DESCRIPTION
The poll-payload job runs on a schedule and runs other jobs when there is a new green payload. This proposal wants to change the following things:
- start triggering items for 4.19
- stop publishing rpms for releases that are GA. The released repositories are New Enough for the two known consumers:
  - Microshift CI
  - Bring Your Own RHEL customers