### PR TITLE
ART-10882: use new rhcos itup cluster for all versions

### DIFF
--- a/jobs/build/rhcos/Jenkinsfile
+++ b/jobs/build/rhcos/Jenkinsfile
@@ -73,10 +73,6 @@ node {
             'multi': 'rhcos--prod-pipeline_jenkins_api-prod-stable-spoke1-dc-iad2-itup-redhat-com',
         ]
 
-        if (params.BUILD_VERSION in ["4.15", "4.16", "4.17", "4.18", "4.19"]) {
-            kubeconfigs['multi'] = 'multi_jenkins_serviceaccount_ocp-virt.prod.psi.redhat.com.kubeconfig'
-        }
-
         // Disabling compose lock for now. Ideally we achieve a stable repo for RHCOS builds in the future,
         // but for now, being this strict is slowing down the delivery of nightlies.
         //lock("compose-lock-${params.BUILD_VERSION}") {


### PR DESCRIPTION
Follows https://github.com/openshift-eng/aos-cd-jobs/pull/4279

Slack [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1732041287908469)