### PR TITLE
Track cert expiry

### DIFF
--- a/scheduled-jobs/scanning/art-notify/check_expired_certificates.py
+++ b/scheduled-jobs/scanning/art-notify/check_expired_certificates.py
@@ -40,6 +40,7 @@ def check_expired_certificates():
     # List of URLs to check
     urls = [
         "art-dash.engineering.redhat.com",
+        "download.devel.redhat.com"
     ]
 
     expired_certificates = []


### PR DESCRIPTION
If any of the certs expire for the URLs in this list, we will know them in the art-notify thread, 30 days in advance