### PR TITLE
add missing secret for microshift-bootc Jenkinsfile

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -102,6 +102,7 @@ node() {
                     file(credentialsId: 'openshift-bot-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                     file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                     string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
+                    file(credentialsId: 'art-publish.app.ci.kubeconfig', variable: 'KUBECONFIG'),
                 ]) {
                     echo "Will run ${cmd}"
                     if (params.IGNORE_LOCKS) {


### PR DESCRIPTION
Fixes
```
  File "/mnt/jenkins-workspace/lds_build_build-microshift-bootc/art-tools/pyartcd/pyartcd/oc.py", line 59, in registry_login
    f'oc --kubeconfig {os.environ["KUBECONFIG"]} registry login')
                       ~~~~~~~~~~^^^^^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'KUBECONFIG'
```

job [logs](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/18/console)