### PR TITLE
Enable telemetry sink for build-sync

### DIFF
--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -165,6 +165,9 @@ node() {
         }
         if (params.TELEMETRY_ENABLED) {
             env.TELEMETRY_ENABLED = "1"
+            if (params.OTEL_EXPORTER_OTLP_ENDPOINT && params.OTEL_EXPORTER_OTLP_ENDPOINT != "") {
+                env.OTEL_EXPORTER_OTLP_ENDPOINT = params.OTEL_EXPORTER_OTLP_ENDPOINT
+            }
         }
         cmd += [
             "build-sync",

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -37,6 +37,8 @@ node() {
                 commonlib.mockParam(),
                 commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                 commonlib.artToolsParam(),
+                commonlib.enableTelemetryParam(),
+                commonlib.telemetryEndpointParam(),
                 string(
                     name: 'ASSEMBLY',
                     description: 'The name of an assembly to sync.',
@@ -160,6 +162,9 @@ node() {
         ]
         if (params.DRY_RUN) {
             cmd << "--dry-run"
+        }
+        if (params.ENABLE_TELEMETRY) {
+            env.TELEMETRY_ENABLED = "1"
         }
         cmd += [
             "build-sync",

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -163,7 +163,7 @@ node() {
         if (params.DRY_RUN) {
             cmd << "--dry-run"
         }
-        if (params.ENABLE_TELEMETRY) {
+        if (params.TELEMETRY_ENABLED) {
             env.TELEMETRY_ENABLED = "1"
         }
         cmd += [

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -120,7 +120,7 @@ def ocpVersionParam(name='MINOR_VERSION', majorVersion='all', extraOpts=[]) {
 
 def enableTelemetryParam() {
     return [
-        name: 'ENABLE_TELEMETRY',
+        name: 'TELEMETRY_ENABLED',
         description: 'Enable or disable sending traces to otel',
         $class: 'BooleanParameterDefinition',
         defaultValue: true
@@ -132,7 +132,7 @@ def telemetryEndpointParam() {
         name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
         description: 'A base endpoint URL for any signal type, with an optionally-specified port number. Helpful for when you’re sending more than one signal to the same endpoint and want one environment variable to control the endpoint',
         $class: 'hudson.model.StringParameterDefinition',
-        defaultValue: 'http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317'
+        defaultValue: ''
     ]
 }
 

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -118,6 +118,23 @@ def ocpVersionParam(name='MINOR_VERSION', majorVersion='all', extraOpts=[]) {
     ]
 }
 
+def enableTelemetryParam() {
+    return [
+        name: 'ENABLE_TELEMETRY',
+        description: 'Enable or disable sending traces to otel',
+        $class: 'BooleanParameterDefinition',
+        defaultValue: true
+    ]
+}
+
+def telemetryEndpointParam() {
+    return [
+        name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
+        description: 'A base endpoint URL for any signal type, with an optionally-specified port number. Helpful for when you’re sending more than one signal to the same endpoint and want one environment variable to control the endpoint',
+        $class: 'hudson.model.StringParameterDefinition',
+        defaultValue: 'http://otel-collector-psi-rhv.hosts.prod.psi.rdu2.redhat.com:4317'
+    ]
+}
 
 def suppressEmailParam() {
     return [


### PR DESCRIPTION
Enable otel telemetry data sink by default, but easily disable it via parameters. We can then start sending data to splunk and get some insight into our pipelines.

<img width="1793" alt="Screenshot 2024-11-27 at 09 52 58" src="https://github.com/user-attachments/assets/208cc837-abcc-49c3-9470-9fe2d1e99c9b">
<img width="1781" alt="Screenshot 2024-11-27 at 09 52 49" src="https://github.com/user-attachments/assets/f3cb15d7-4e2e-4953-985c-e14d8c3f347a">
<img width="1908" alt="Screenshot 2024-11-27 at 09 45 07" src="https://github.com/user-attachments/assets/73c18940-d236-4395-9514-0644b0753c08">
