### PR TITLE
ART-11441: [konflux] Trigger builds in new cluster

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -99,7 +99,7 @@ node() {
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                     string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                    file(credentialsId: 'openshift-bot-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                     file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                     string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
                     file(credentialsId: 'art-publish.app.ci.kubeconfig', variable: 'KUBECONFIG'),

--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -128,7 +128,7 @@ node {
 
             buildlib.withAppCiAsArtPublish() {
                 withCredentials([
-                            file(credentialsId: 'openshift-bot-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
+                            file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS')


### PR DESCRIPTION
Created new ServiceAccount [openshift-art-bot](https://console-openshift-console.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/k8s/ns/ocp-art-tenant/serviceaccounts/openshift-art-bot) and exported the kubeconfig to Jenkins secrets

Test run [successful](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ashwin-aos-cd-jobs/job/build%252Focp4-konflux/12/console).

New build: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-18/pipelineruns/ose-4-18-openshift-base-rhel9-584t5