### PR TITLE
deprecate 2015 IT cert

### DIFF
--- a/tekton-pipelines/images/artcd/Containerfile
+++ b/tekton-pipelines/images/artcd/Containerfile
@@ -22,7 +22,6 @@ LABEL name="openshift-art/art-cd" \
 
 # Trust Red Hat IT Root CA certificates
 RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
-  && curl -fLo /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
   && curl -fLo /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://certs.corp.redhat.com/certs/RH-IT-Root-CA.crt \
  && update-ca-trust extract
 

--- a/tekton-pipelines/images/artcd/Containerfile.base
+++ b/tekton-pipelines/images/artcd/Containerfile.base
@@ -6,7 +6,6 @@ LABEL name="openshift-art/artcd-base" \
 
 # Trust Red Hat IT Root CA certificates and add repos
 RUN curl -fLo /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
- && curl -fLo /etc/pki/ca-trust/source/anchors/2015-IT-Root-CA.pem https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
  && update-ca-trust extract 
 
 # Copy repository configurations for software installations


### PR DESCRIPTION
2015 cert is deprecated on https://certs.corp.redhat.com/certs/