### PR TITLE
Revert "enable 4.13 konflux scan"

### DIFF
--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile
@@ -27,7 +27,6 @@ node {
             "--working-dir=${WORKSPACE}/artcd_working",
             "--config=./config/artcd.toml",
             "schedule-ocp4-scan-konflux",
-            "--version=4.13", // to be removed once we have full capacity
             "--version=4.14", // to be removed once we have full capacity
             "--version=4.15", // to be removed once we have full capacity
             "--version=4.16", // to be removed once we have full capacity


### PR DESCRIPTION
Reverts openshift-eng/aos-cd-jobs#4321

commits haven't synced to priv yet