### PR TITLE
ocp4-konflux: Build OLM bundles by default

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -95,7 +95,7 @@ node {
                     booleanParam(
                         name: 'SKIP_BUNDLE_BUILD',
                         description: '(For testing) Skip the OLM bundle build step',
-                        defaultValue: true,  // Default to true until we believe bundle build is stable.
+                        defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
                 ]
             ],


### PR DESCRIPTION
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/2498/console shows it can trigger olm_bundle_konflux after operator build.