### PR TITLE
OCPBUGS-48831: Fix bash glob exclusion in S3-rhcossync.sh

### DIFF
--- a/jobs/build/rhcos_sync/S3-rhcossync.sh
+++ b/jobs/build/rhcos_sync/S3-rhcossync.sh
@@ -61,7 +61,7 @@ function downloadImages() {
 }
 
 function genSha256() {
-    sha256sum *[!rhcos-id.txt] > sha256sum.txt
+    sha256sum !(rhcos-id.txt) > sha256sum.txt
     ls -lh
     cat sha256sum.txt
 }

--- a/jobs/build/rhcos_sync/S3-rhcossync.sh
+++ b/jobs/build/rhcos_sync/S3-rhcossync.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -exo pipefail
+shopt -s extglob
 
 # Where to put this on the s3 mirror, such as '4.2' or 'pre-release':
 RHCOS_MIRROR_PREFIX=


### PR DESCRIPTION
- sha256sum to match everything in cwd except rhcos-id.txt specifically
- https://issues.redhat.com/browse/OCPBUGS-48831