### PR TITLE
olm_bundle_konflux: Add PLR_TEMPLATE_COMMIT parameter

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -44,7 +44,7 @@ node {
                     ),
                     string(
                         name: 'PLR_TEMPLATE_COMMIT',
-                        description: 'Override the Pipeline Run template commit from openshift-priv/art-konflux-template; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2',
+                        description: '(Optional) Override the Pipeline Run template commit from openshift-priv/art-konflux-template; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2',
                         defaultValue: "",
                         trim: true,
                     ),

--- a/jobs/build/olm_bundle_konflux/Jenkinsfile
+++ b/jobs/build/olm_bundle_konflux/Jenkinsfile
@@ -82,6 +82,12 @@ node() {
                     description: 'Rebuild bundle containers, even if they already exist for given operator NVRs',
                     defaultValue: false,
                 ),
+                string(
+                    name: 'PLR_TEMPLATE_COMMIT',
+                    description: '(Optional) Override the Pipeline Run template commit from openshift-priv/art-konflux-template; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2',
+                    defaultValue: "",
+                    trim: true,
+                ),
                 booleanParam(
                     name: 'DRY_RUN',
                     description: 'Just show what would happen, without actually executing the steps',
@@ -149,6 +155,9 @@ node() {
                     cmd << "--exclude=${exclude.join(',')}"
                 if (params.FORCE_BUILD)
                     cmd << "--force"
+                if (params.PLR_TEMPLATE_COMMIT) {
+                    cmd << "--plr-template=${params.PLR_TEMPLATE_COMMIT}"
+                }
 
                 // Run pipeline
                 timeout(activity: true, time: 60, unit: 'MINUTES') { // if there is no log activity for 1 hour


### PR DESCRIPTION
Similar to the ocp4-konflux job, this parameter can be used to override Pipeline Run template commit from openshift-priv/art-konflux-template; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2'

pyartcd already supports `--plr-template`. We just need to expose the option to Jenkins.