### PR TITLE
Fix rhcos sync job

### DIFF
--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -23,8 +23,15 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     // but 4.19 rhcos url in group.yml will be pointing to 4.19 rhcos stream.
     // 418.94.202410090804-0 -> 4.18-9.4
     buildParts = rhcosBuild.split("\\.")
-    ocpStream = buildParts[0][0] + '.' + buildParts[0][1..-1]
-    rhelStream = buildParts[1][0] + '.' + buildParts[1][1..-1]
+    ocpStream = ocpVersion
+    minor = ocpVersion.split("\\.")
+    if ( minor[1] > 18 ) {
+        // For 4.19 the rhcosBuild name is in format 9.6.20250121-0
+        rhelStream = buildParts[0] + '.' + buildParts[1]
+    } else {
+        // For 4.18 and below the rhcosBuild name is in format 418.94.202410090804-0
+        rhelStream = buildParts[1][0] + '.' + buildParts[1][1..-1]
+    }
     stream = "${ocpStream}-${rhelStream}"
 
     baseUrl = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/${stream}/builds"

--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -28,11 +28,12 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     if ( minor[1] > 18 ) {
         // For 4.19 the rhcosBuild name is in format 9.6.20250121-0
         rhelStream = buildParts[0] + '.' + buildParts[1]
+        stream = "rhel-${rhelStream}"
     } else {
         // For 4.18 and below the rhcosBuild name is in format 418.94.202410090804-0
         rhelStream = buildParts[1][0] + '.' + buildParts[1][1..-1]
+        stream = "${ocpStream}-${rhelStream}"
     }
-    stream = "${ocpStream}-${rhelStream}"
 
     baseUrl = "https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/${stream}/builds"
     buildUrl = "${baseUrl}/${rhcosBuild}/${arch}"


### PR DESCRIPTION
rhcos sync job is failing https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frhcos_sync/315/console
there is a format change in installer repo https://github.com/openshift/installer/commit/194cc0682cee2645e58bbff2346b99c83aacd7ab
thus our request address needs to be updated, for 4.18 and below keep the default behaviour ( maybe 4.18 will not be used now )

test run https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ximhan/job/build%252Frhcos_sync/11/console ( the major sync part is success)