### PR TITLE
fix: check for file type before zstd

### DIFF
--- a/extract.sh
+++ b/extract.sh
@@ -22,17 +22,15 @@ if [[ -n "${3-}" ]]; then
   rmdir keep/
 fi
 
-rm -rf "$VERSION"
+rm -rf "$VERSION" temp_extract
 mkdir "$VERSION"
 
 for rpm in *.rpm; do
   arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}' <<<"$rpm")"
-  if [[ "$rpm" == *el9* && $(file -b --mime-type "$rpm") == "application/zstd-compressed"  ]]; then
-    rpm2cpio "${rpm}" | zstd -d | cpio -idm --quiet ./usr/bin/coreos-installer
-  else
-    rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer
-  fi
-  mv usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
+  mkdir temp_extract
+  aunpack "$rpm" --extract-to=temp_extract
+  mv temp_extract/usr/bin/coreos-installer "$VERSION/coreos-installer_$arch"
+  rm -rf temp_extract/
 done
 
 if [[ -f ${VERSION}/coreos-installer_amd64 ]]; then

--- a/extract.sh
+++ b/extract.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 WORKDIR="$1"
 cd "$WORKDIR"
@@ -27,7 +27,7 @@ mkdir "$VERSION"
 
 for rpm in *.rpm; do
   arch="$(awk -F'[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}' <<<"$rpm")"
-  if [[ "$rpm" == *el9* ]]; then
+  if [[ "$rpm" == *el9* && $(file -b --mime-type "$rpm") == "application/zstd-compressed"  ]]; then
     rpm2cpio "${rpm}" | zstd -d | cpio -idm --quiet ./usr/bin/coreos-installer
   else
     rpm2cpio "${rpm}" | cpio -idm --quiet ./usr/bin/coreos-installer


### PR DESCRIPTION
When running:
```
./extract.sh '/mnt/jenkins-workspace/ilds_build_coreos-installer_sync/coreos-installer_sync' 'v0.21.0-3' ''
```
I get the following output:

```
+ WORKDIR=/mnt/jenkins-workspace/ilds_build_coreos-installer_sync/coreos-installer_sync
+ cd /mnt/jenkins-workspace/ilds_build_coreos-installer_sync/coreos-installer_sync
+ VERSION=v0.21.0-3
+ ARCHES=
+ [[ -n '' ]]
+ rm -rf v0.21.0-3
+ mkdir v0.21.0-3
+ for rpm in *.rpm
++ awk '-F[.]' '{a = $(NF-1); print a=="x86_64" ? "amd64" : a=="aarch64" ? "arm64" : a}'
+ arch=arm64
+ [[ coreos-installer-0.21.0-3.el9_4.aarch64.rpm == *el9* ]]
+ rpm2cpio coreos-installer-0.21.0-3.el9_4.aarch64.rpm
+ zstd -d
+ cpio -idm --quiet ./usr/bin/coreos-installer
zstd: /*stdin*\: unsupported format
cpio: premature end of archive
```

which suggests that `zstd -d` is failing because the RPM file is not compressed with `zstd`. We should check whether the RPM is actually zstd-compressed before applying `zstd -d`. 