### PR TITLE
Disable telemetry

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -123,7 +123,7 @@ def enableTelemetryParam() {
         name: 'TELEMETRY_ENABLED',
         description: 'Enable or disable sending traces to otel',
         $class: 'BooleanParameterDefinition',
-        defaultValue: true
+        defaultValue: false
     ]
 }
 


### PR DESCRIPTION
Telemetry is currently misconfigured and polluting our logs with `error`s. Disabling until we make it work.