### PR TITLE
build-fbc: Use registry config file for pull secret

### DIFF
--- a/jobs/build/build-fbc/Jenkinsfile
+++ b/jobs/build/build-fbc/Jenkinsfile
@@ -114,8 +114,7 @@ node() {
                 string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                 string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                 file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
-                string(credentialsId: 'konflux-art-images-username', variable: 'KONFLUX_ART_IMAGES_USERNAME'),
-                string(credentialsId: 'konflux-art-images-password', variable: 'KONFLUX_ART_IMAGES_PASSWORD'),
+                file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                 file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
             ]) {
                 def cmd = [


### PR DESCRIPTION
This is to allow to build FBC for Brew built OLM bundles.

Currently username and password is used for registry auth, but it has a limitation that `oc` command will use the same login for all registries. It makes impossible to use Konflux image registry and Brew registry at the same time. By switching to registry config file, we use different credentials for different registries.

Test build https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/yuxzhu/job/aos-cd-builds/job/build%252Fbuild-fbc/29/console (A konflux FBC build for OLM bundle from Brew registry)