### PR TITLE
promote: Remove SKIP_ATTACHED_BUG_CHECK option

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -74,11 +74,6 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
-                        name: 'SKIP_ATTACHED_BUG_CHECK',
-                        description: 'Skip attached bug check',
-                        defaultValue: false,
-                    ),
-                    booleanParam(
                         name: 'SKIP_SIGNING',
                         description: 'Do not sign the release (legacy).',
                         defaultValue: false,
@@ -107,7 +102,6 @@ node {
 
     commonlib.checkMock()
     def (major, minor) = commonlib.extractMajorMinorVersionNumbers(params.VERSION)
-    def skipAttachedBugCheck = params.SKIP_ATTACHED_BUG_CHECK
     def next_minor = "${major}.${minor + 1}"
     if (params.DRY_RUN) {
         currentBuild.displayName += " (dry-run)"
@@ -141,9 +135,6 @@ node {
             "--group=openshift-${params.VERSION}",
             "--assembly=${params.ASSEMBLY}",
         ]
-        if (skipAttachedBugCheck) {
-            cmd << "--skip-attached-bug-check"
-        }
         if (params.SKIP_IMAGE_LIST) {
             cmd << "--skip-image-list"
         }


### PR DESCRIPTION
Proposing to remove the switch SKIP_ATTACHED_BUG_CHECK. This prevents this check from running, and think this should always run. If it is needed to ignore the result, please create a PR to the assembly definition with content like:

```yaml
promotion_permits:
  - code: ATTACHED_BUGS
    why: |
      - OCPBUGS-123 is fixed in 4.16.56 but OCPBUGS-122 did not make it into 4.17.45
      - OCPBUGS-456 is fixed in 4.16.56 but OCPBUGS-455 did not make it into 4.17.45
```

This enables to query assembly definitions from when this happened. This info may get queried by ERT or other interested parties.