### PR TITLE
Call pyartcd pipelines at log-level=info

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -75,7 +75,7 @@ node() {
                 sh "mkdir -p ./artcd_working"
                 def cmd = [
                     "artcd",
-                    "-vv",
+                    "-v",
                     "--working-dir=./artcd_working",
                     "--config", "./config/artcd.toml",
                 ]

--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -81,7 +81,7 @@ node() {
                 sh "mkdir -p ./artcd_working"
                 def cmd = [
                     "artcd",
-                    "-vv",
+                    "-v",
                     "--working-dir=./artcd_working",
                     "--config", "./config/artcd.toml",
                 ]

--- a/jobs/build/ocp4_scan/Jenkinsfile
+++ b/jobs/build/ocp4_scan/Jenkinsfile
@@ -84,7 +84,7 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                 buildlib.init_artcd_working_dir()
                 cmd = [
                     "artcd",
-                    "-vv",
+                    "-v",
                     "--working-dir=${artcd_working}",
                     "--config=./config/artcd.toml",
                 ]

--- a/jobs/build/rebuild/Jenkinsfile
+++ b/jobs/build/rebuild/Jenkinsfile
@@ -85,7 +85,7 @@ node {
             sh "mkdir -p ./artcd_working"
             def cmd = [
                 "artcd",
-                "-vv",
+                "-v",
                 "--working-dir=./artcd_working",
                 "--config", "./config/artcd.toml",
             ]

--- a/jobs/build/scan-osh/Jenkinsfile
+++ b/jobs/build/scan-osh/Jenkinsfile
@@ -66,7 +66,7 @@ node() {
         stage("kick-off-scans") {
             def cmd = [
                     "artcd",
-                    "-vv",
+                    "-v",
                     "--working-dir=./artcd_working",
                     "--config=./config/artcd.toml",
             ]

--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -41,7 +41,7 @@ node() {
 
     def cmd = [
         "artcd",
-        "-vv",
+        "-v",
         "--working-dir=${artcd_working}",
         "--config=./config/artcd.toml",
         "images-health",

--- a/scheduled-jobs/build/ocp4_scan/Jenkinsfile
+++ b/scheduled-jobs/build/ocp4_scan/Jenkinsfile
@@ -23,7 +23,7 @@ node {
     stage("scan") {
         cmd = [
             "artcd",
-            "-vv",
+            "-v",
             "--working-dir=${WORKSPACE}/artcd_working",
             "--config=./config/artcd.toml",
             "schedule-ocp4-scan",

--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.hp
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.hp
@@ -23,7 +23,7 @@ node {
     stage("scan") {
         cmd = [
             "artcd",
-            "-vv",
+            "-v",
             "--working-dir=${WORKSPACE}/artcd_working",
             "--config=./config/artcd.toml",
             "schedule-ocp4-scan-konflux"

--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.lp
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.lp
@@ -23,7 +23,7 @@ node {
     stage("scan") {
         cmd = [
             "artcd",
-            "-vv",
+            "-v",
             "--working-dir=${WORKSPACE}/artcd_working",
             "--config=./config/artcd.toml",
             "schedule-ocp4-scan-konflux"


### PR DESCRIPTION
-vv (debug) results in loads of noisy debug logs in console