### PR TITLE
add jenkins service account to bootc job

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -105,6 +105,8 @@ node() {
                     file(credentialsId: 'art-publish.app.ci.kubeconfig', variable: 'KUBECONFIG'),
                     string(credentialsId: 'konflux-art-images-username', variable: 'KONFLUX_ART_IMAGES_USERNAME'),
                     string(credentialsId: 'konflux-art-images-password', variable: 'KONFLUX_ART_IMAGES_PASSWORD'),
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                 ]) {
                     echo "Will run ${cmd}"
                     if (params.IGNORE_LOCKS) {


### PR DESCRIPTION
Fixes failure: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift-bootc/104/console

```
  File "/mnt/jenkins-workspace/lds_build_build-microshift-bootc/art-tools/pyartcd/pyartcd/jenkins.py", line 58, in init_jenkins
    username=os.environ['JENKINS_SERVICE_ACCOUNT'],
             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'JENKINS_SERVICE_ACCOUNT'
```