### PR TITLE
ART-13013 Add rebase failures notification to art-notify

### DIFF
--- a/scheduled-jobs/scanning/art-notify/Jenkinsfile
+++ b/scheduled-jobs/scanning/art-notify/Jenkinsfile
@@ -1,8 +1,9 @@
 
 node() {
     checkout scm
-    commonlib = load("pipeline-scripts/commonlib.groovy")
-    slacklib = commonlib.slacklib
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+    def slacklib = commonlib.slacklib
 
     properties([
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '100')),
@@ -12,22 +13,23 @@ node() {
             $class: 'ParametersDefinitionProperty',
             parameterDefinitions: [
                 string(
-                        name: 'CHANNEL',
-                        description: 'Where should we notify about ART threads',
-                        trim: true,
-                        defaultValue: "#ocp-sustaining-art-collaboration"
-                    ),
-                    booleanParam(
-                        name: 'DRY_RUN',
-                        description: 'Will not message to slack, if dry run is true',
-                        defaultValue: false
-                    ),
+                    name: 'CHANNEL',
+                    description: 'Where should we notify about ART threads',
+                    trim: true,
+                    defaultValue: "#ocp-sustaining-art-collaboration"
+                ),
+                commonlib.dryrunParam(description='Will not message to slack, if dry run is true'),
+                commonlib.artToolsParam(),
                 commonlib.mockParam(),
             ]
         ]
     ])
 
     commonlib.checkMock()
+
+    stage('Initialize') {
+        commonlib.shell("pip install slack_bolt")
+    }
 
     stage('Check unresolved ART threads') {
         try {
@@ -36,7 +38,8 @@ node() {
                                 string(credentialsId: "art-bot-slack-user-token", variable: "SLACK_USER_TOKEN"),
                                 string(credentialsId: "art-bot-slack-signing-secret", variable: "SLACK_SIGNING_SECRET"),
                                 string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
-                                string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN')
+                                string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                                string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                             ]) {
                 withEnv(["CHANNEL=${params.CHANNEL}", "DRY_RUN=${params.DRY_RUN}"]) {
                     retry(10) {

--- a/scheduled-jobs/scanning/art-notify/rebase_failures.py
+++ b/scheduled-jobs/scanning/art-notify/rebase_failures.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from artcommonlib import redis
+
+
+async def get_rebase_failures():
+    failures = {}
+
+    async def _get_failures_for_engine(engine):
+        redis_branch = f'count:rebase-failure:{engine}'
+        print(f'Reading from {redis_branch}...')
+        failed_images = await redis.get_keys(f'{redis_branch}:*')
+
+        if failed_images:
+            fail_counters = await redis.get_multiple_values(failed_images)
+            for image, fail_counter in zip(failed_images, fail_counters):
+                image_name = image.split(':')[-1]
+                version = image.split(':')[-2]
+                failures.setdefault(engine, {}).setdefault(version, {})[image_name] = fail_counter
+
+    await asyncio.gather(*[_get_failures_for_engine(engine) for engine in ['brew', 'konflux']])
+    return failures
+
+
+if __name__ == '__main__':
+    import asyncio
+
+    async def main():
+        print(await get_rebase_failures())
+    asyncio.run(main())


### PR DESCRIPTION
We stopped breaking ocp4-konflux pipelines on rebase failures, and we started storing them in Redis instead of spamming slack. Adding a check to our `art-notify` scheduled job to ping us about failing images.

Test run produced [this message](https://redhat-internal.slack.com/archives/C08J61YQNMU/p1749744122778729) (I deliberately removed the `@` to avoid useless pings).

Needs https://github.com/openshift-eng/art-tools/pull/1688

Ref. [ART-13013](https://issues.redhat.com/browse/ART-13013)