### PR TITLE
[rhcos-sync] Do not pip install awscli

### DIFF
--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -50,7 +50,6 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     dir ( rhcosWorking ) {
         sh("wget ${metaUrl} -O meta.json")
         artifacts.add("${rhcosWorking}/meta.json")
-        commonlib.shell(script: "pip install awscli")
     }
 }
 


### PR DESCRIPTION
Directly doing "pip install awscli" via shell is failing right now in buildvm
I have not looked at the root cause, but suspect that there is a dependency conflict.
Instead of installing it via shell, we can install it as part of pyartcd dependency
https://github.com/openshift-eng/art-tools/pull/1483/files