### PR TITLE
feat(ocp4-konflux): add telemetry configuration with custom defaults

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -21,7 +21,6 @@ node {
         Build OCP 4 images with Konflux
     """)
 
-
     // Expose properties for a parameterized build
     properties(
         [
@@ -102,6 +101,8 @@ node {
                         description: '(For testing) Skip the OLM bundle build step',
                         defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
+                    commonlib.enableTelemetryParam() + [defaultValue: true],
+                    commonlib.telemetryEndpointParam() + [defaultValue: 'http://internal-ae376ae27a0164533897f63672a9a423-1051671585.us-east-1.elb.amazonaws.com:4317'],
                 ]
             ],
         ]
@@ -179,7 +180,14 @@ node {
                             file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                 ]){
-                    withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
+                    def envVars = ["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']
+                    if (params.TELEMETRY_ENABLED) {
+                        envVars << "TELEMETRY_ENABLED=1"
+                        if (params.OTEL_EXPORTER_OTLP_ENDPOINT && params.OTEL_EXPORTER_OTLP_ENDPOINT != "") {
+                            envVars << "OTEL_EXPORTER_OTLP_ENDPOINT=${params.OTEL_EXPORTER_OTLP_ENDPOINT}"
+                        }
+                    }
+                    withEnv(envVars) {
                         buildlib.init_artcd_working_dir()
                         try {
                             sh(script: cmd.join(' '), returnStdout: true)


### PR DESCRIPTION
## Summary
  Added TELEMETRY_ENABLED and OTEL_EXPORTER_OTLP_ENDPOINT parameters with custom defaults. Telemetry is enabled by default with internal endpoint
   for OpenTelemetry observability data collection.

  ## Problem
  **Before:** No telemetry configuration in ocp4-konflux pipeline
  **After:** Telemetry enabled by default with internal AWS endpoint for observability data collection

  ## Changes
  - `jobs/build/ocp4-konflux/Jenkinsfile`: Added telemetry parameters with custom defaults and conditional environment setup

  **Technical Notes**
  Uses commonlib functions with parameter overrides. Conditionally adds telemetry environment variables when enabled.

  ## Tests
  - Custom trace example: https://jaeger-ui-art-alerting.apps.artc2023.pc3z.p1.openshiftapps.com/trace/9465c68f52882e08f9699e80f241660e
  - New Jaeger UI with HTTPS and OAuth: https://jaeger-ui-art-alerting.apps.artc2023.pc3z.p1.openshiftapps.com/