### PR TITLE
Add new Jira template to artcd config

### DIFF
--- a/config/artcd.toml
+++ b/config/artcd.toml
@@ -22,3 +22,4 @@ url = "https://issues.redhat.com"
 [jira.templates]
 ocp4 = "ART-4223"
 ocp3 = "ART-4234"
+ocp4-konflux = "ART-13405"


### PR DESCRIPTION
The legacy template ([ART-4223](https://issues.redhat.com/browse/ART-4223)) has subtasks nobody is looking at. The proposal is to smoothly transition towards a YAML-based template file we can commit to ocp-build-data, and make use of version control should we decide to change the release ticket formatting or content.

A new template has been created at [ART-13405](https://issues.redhat.com/browse/ART-13405), so update `artcd.toml` to also reference it. This template would then be referenced by `prepare-release-konflux`, so that all Konflux release Jiras will adhere to the new format. (Note that only tiny details have changed in the description so far).