### PR TITLE
Update default bug labels

### DIFF
--- a/scheduled-jobs/build/sync-ci-images/Jenkinsfile
+++ b/scheduled-jobs/build/sync-ci-images/Jenkinsfile
@@ -176,7 +176,7 @@ node {
                     } else {
                         withCredentials([string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
                             if ( (major == 4 && minor >= 12) || major > 4 ) {
-                                other_args = '--add-label "bugzilla/valid-bug"'
+                                other_args = '--add-label "jira/valid-bug"'
                                 for ( label in params.ADD_LABELS.split() ) {
                                     other_args += " --add-label '${label}'"
                                 }


### PR DESCRIPTION
cherry-pick-approved is not needed now
backport-risk-assessed should be added by approver
ref https://groups.google.com/a/redhat.com/g/aos-devel/c/qzFJTxPot64/m/p_2GpJkzAAAJ