### PR TITLE
Provide jenkins sa creds to olm_bundle_konflux

### DIFF
--- a/jobs/build/olm_bundle_konflux/Jenkinsfile
+++ b/jobs/build/olm_bundle_konflux/Jenkinsfile
@@ -126,6 +126,8 @@ node() {
                 file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                 file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                 file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
             ]) {
                 def cmd = [
                     "artcd",


### PR DESCRIPTION
This is needed for https://github.com/openshift-eng/art-tools/pull/1820/files