### PR TITLE
feat(ocp4-konflux): update telemetry ELB endpoint

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -102,7 +102,7 @@ node {
                         defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
                     commonlib.enableTelemetryParam() + [defaultValue: true],
-                    commonlib.telemetryEndpointParam() + [defaultValue: 'http://internal-a68c498d3b8f34033b0651d295a2fd2a-518993245.us-east-1.elb.amazonaws.com:4317'],
+                    commonlib.telemetryEndpointParam() + [defaultValue: 'http://internal-a34de5d9970db4014a31eaab2a6ecdf5-1590680375.us-east-1.elb.amazonaws.com:4317'],
                 ]
             ],
         ]


### PR DESCRIPTION
## Summary
Updated the internal AWS ELB endpoint for telemetry data collection in the OCP4 Konflux pipeline configuration.

## Problem
**Before:** Pipeline was using old internal ELB endpoint internal-a68c498d3b8f34033b0651d295a2fd2a-518993245.us-east-1.elb.amazonaws.com for telemetry data collection
**After:** Pipeline now uses new internal ELB endpoint internal-a34de5d9970db4014a31eaab2a6ecdf5-1590680375.us-east-1.elb.amazonaws.com for telemetry data collection

## Changes
- `jobs/build/ocp4-konflux/Jenkinsfile`: Updated telemetryEndpointParam default value to use new ELB endpoint

**Technical Notes**
Simple configuration update maintaining the same port 4317 for OTLP protocol while pointing to the new internal AWS load balancer endpoint.