### PR TITLE
feat(telemetry): centralize konflux telemetry configuration in commonlib

### DIFF
--- a/jobs/build/build-sync-konflux/Jenkinsfile
+++ b/jobs/build/build-sync-konflux/Jenkinsfile
@@ -38,8 +38,6 @@ node() {
                 commonlib.mockParam(),
                 commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                 commonlib.artToolsParam(),
-                commonlib.enableTelemetryParam(),
-                commonlib.telemetryEndpointParam(),
                 string(
                     name: 'ASSEMBLY',
                     description: 'The name of an assembly to sync.',
@@ -108,6 +106,8 @@ node() {
                     description : 'WARNING: Only enable this if a payload containing embargoed build(s) is being promoted after embargo lift',
                     defaultValue: false,
                 ),
+                commonlib.enableTelemetryParam(),
+                commonlib.telemetryEndpointParam(),
             ],
         ]
     ])  // Please update README.md if modifying parameter names or semantics

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -38,8 +38,6 @@ node() {
                 commonlib.mockParam(),
                 commonlib.ocpVersionParam('BUILD_VERSION', '4'),
                 commonlib.artToolsParam(),
-                commonlib.enableTelemetryParam(),
-                commonlib.telemetryEndpointParam(),
                 string(
                     name: 'ASSEMBLY',
                     description: 'The name of an assembly to sync.',
@@ -169,12 +167,6 @@ node() {
         ]
         if (params.DRY_RUN) {
             cmd << "--dry-run"
-        }
-        if (params.TELEMETRY_ENABLED) {
-            env.TELEMETRY_ENABLED = "1"
-            if (params.OTEL_EXPORTER_OTLP_ENDPOINT && params.OTEL_EXPORTER_OTLP_ENDPOINT != "") {
-                env.OTEL_EXPORTER_OTLP_ENDPOINT = params.OTEL_EXPORTER_OTLP_ENDPOINT
-            }
         }
         cmd += [
             "build-sync",

--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -101,8 +101,8 @@ node {
                         description: '(For testing) Skip the OLM bundle build step',
                         defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
-                    commonlib.enableTelemetryParam() + [defaultValue: true],
-                    commonlib.telemetryEndpointParam() + [defaultValue: 'http://internal-a344ed20604f143d7955b3c06c517eb8-1688607883.us-east-1.elb.amazonaws.com:4317'],
+                    commonlib.enableTelemetryParam(),
+                    commonlib.telemetryEndpointParam(),
                 ]
             ],
         ]

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -125,7 +125,7 @@ def enableTelemetryParam() {
         name: 'TELEMETRY_ENABLED',
         description: 'Enable or disable sending traces to otel',
         $class: 'BooleanParameterDefinition',
-        defaultValue: false
+        defaultValue: true
     ]
 }
 
@@ -134,7 +134,7 @@ def telemetryEndpointParam() {
         name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
         description: 'A base endpoint URL for any signal type, with an optionally-specified port number. Helpful for when you’re sending more than one signal to the same endpoint and want one environment variable to control the endpoint',
         $class: 'hudson.model.StringParameterDefinition',
-        defaultValue: ''
+        defaultValue: 'http://internal-a344ed20604f143d7955b3c06c517eb8-1688607883.us-east-1.elb.amazonaws.com:4317'
     ]
 }
 


### PR DESCRIPTION
  **Summary**

  Centralized telemetry configuration in commonlib with konflux-appropriate defaults and removed telemetry from regular build-sync job.

  **Problem**

  Before: Manual telemetry default overrides scattered across jobs, inconsistent parameter positioning, and telemetry enabled on non-konflux jobs.

  After: Clean centralized telemetry defaults in commonlib functions, consistent positioning, and konflux-only telemetry.

  **Changes**

  - pipeline-scripts/commonlib.groovy: Updated telemetry functions with enabled defaults + SigNoz endpoint
  - jobs/build/ocp4-konflux/Jenkinsfile: Removed manual overrides, moved params to end
  - jobs/build/build-sync-konflux/Jenkinsfile: Standardized implementation, removed overrides
  - jobs/build/build-sync/Jenkinsfile: Removed all telemetry (konflux-only feature)