### PR TITLE
add jira token in ocp4-konflux job

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -195,6 +195,7 @@ node {
                             string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                             file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                             string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                             file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),


### PR DESCRIPTION
fix error
```
ValueError: elliott requires login credentials for https://issues.redhat.com/. Set a JIRA_TOKEN env var 
2025-08-19 11:52:34,357 art_tools.artcommonlib.exectools INFO Executing:cmd_assert_async: elliott --assembly stream --group=openshift-4.17 find-bugs:golang --analyze --update-tracker
```

https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/15510/consoleFull