### PR TITLE
feat(ocp4-konflux): add network mode override parameter

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -129,6 +129,16 @@ node {
                         description: '(For testing) Skip the OLM bundle build step',
                         defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
+                    choice(
+                        name: 'NETWORK_MODE',
+                        description: 'Override network mode for Konflux builds',
+                        choices: [
+                            "",
+                            "hermetic",
+                            "internal-only",
+                            "open"
+                        ].join("\n")
+                    ),
                     commonlib.enableTelemetryParam(),
                     commonlib.telemetryEndpointParam(),
                 ]
@@ -199,6 +209,9 @@ node {
             }
             if (params.USE_MASS_REBUILD_LOCKS) {
                cmd << "--use-mass-rebuild-locks"
+            }
+            if (params.NETWORK_MODE && params.NETWORK_MODE != "") {
+                cmd << "--network-mode=${params.NETWORK_MODE}"
             }
 
             // Needed to detect manual builds


### PR DESCRIPTION
## Summary
Add NETWORK_MODE parameter to ocp4-konflux job to enable testing hermetic builds without modifying config files.

## Problem
**Before:** No way to override network mode for Konflux builds at runtime, requiring config file modifications for testing
**After:** Operators can specify network mode (hermetic/internal-only/open) directly via Jenkins parameter

## Usage
Use this parameter when testing hermetic build conversions or when RPM lockfiles are missing. Select from:
- **hermetic**: Force hermetic mode for testing conversions
- **internal-only**: Use internal network access only  
- **open**: Bypass hermetic restrictions when lockfiles unavailable
- **(empty)**: Use default configuration from image/group settings

This enables testing hermetic builds on images that haven't been converted yet, or debugging build failures during the hermetic conversion process without modifying ocp-build-data config files.