### PR TITLE
update BUILD_VERSION for bundle and fbc job

### DIFF
--- a/jobs/build/build-fbc/Jenkinsfile
+++ b/jobs/build/build-fbc/Jenkinsfile
@@ -17,10 +17,10 @@ node() {
                     defaultValue: "",
                     trim: true
                 ),
-                choice(
+                string(
                     name: 'BUILD_VERSION',
-                    choices: commonlib.ocpVersions,
-                    description: 'OCP Version',
+                    description: 'For example, 4.19 (for OCP), 1.6.3 (for OADP)',
+                    trim: true,
                 ),
                 string(
                     name: 'GROUP',

--- a/jobs/build/olm_bundle_konflux/Jenkinsfile
+++ b/jobs/build/olm_bundle_konflux/Jenkinsfile
@@ -28,10 +28,10 @@ node() {
                     defaultValue: "",
                     trim: true
                 ),
-                choice(
+                string(
                     name: 'BUILD_VERSION',
-                    choices: commonlib.ocpVersions,
-                    description: 'OCP Version',
+                    description: 'For example, 4.19 (for OCP), 1.6.3 (for OADP)',
+                    trim: true,
                 ),
                 string(
                     name: 'GROUP',


### PR DESCRIPTION
OADP / MTA / MTC / Logging have different versions and do not conform to the OCP's choices. Changing `BUILD_VERSION` to a string, to allow non-OCP builds to use the same job