### PR TITLE
Add RELEASE_JIRA parameter to release-from-fbc job

### DIFF
--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -63,6 +63,12 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
+                    string(
+                        name: 'RELEASE_JIRA',
+                        description: 'Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). Will be referenced in the shipment MR and updated with the MR link.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
                     commonlib.enableTelemetryParam(),
                     commonlib.telemetryEndpointParam(),
                 ]
@@ -118,6 +124,12 @@ node {
             if (targetDate) {
                 cmd << "--target-release-date"
                 cmd << "${targetDate}"
+            }
+
+            def releaseJira = params.RELEASE_JIRA?.trim()
+            if (releaseJira) {
+                cmd << "--release-jira"
+                cmd << "${releaseJira}"
             }
 
             if (params.DRY_RUN) {

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -76,7 +76,7 @@ node {
                     ),
                     string(
                         name: 'RELEASE_JIRA',
-                        description: 'Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). Will be referenced in the shipment MR and updated with the MR link.',
+                        description: 'Optional JIRA ticket key or URL for the release request (e.g. OADP-1234 or https://redhat.atlassian.net/browse/OADP-1234). Will be referenced in the shipment MR and updated with the MR link.',
                         defaultValue: "",
                         trim: true,
                     ),

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -74,6 +74,12 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
+                    string(
+                        name: 'RELEASE_JIRA',
+                        description: 'Optional JIRA ticket URL for the release request (e.g. https://redhat.atlassian.net/browse/OADP-1234). Will be referenced in the shipment MR and updated with the MR link.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
                     commonlib.enableTelemetryParam(),
                     commonlib.telemetryEndpointParam(),
                 ]
@@ -132,6 +138,12 @@ node {
                     "${params.ASSEMBLY}",
                     "--create-mr"
                 ]
+
+                def releaseJira = params.RELEASE_JIRA?.trim()
+                if (releaseJira) {
+                    cmd << "--release-jira"
+                    cmd << "${releaseJira}"
+                }
 
                 if (fbcPullspecs) {
                     cmd += ["--fbc-pullspecs", fbcPullspecs]


### PR DESCRIPTION
Add an optional RELEASE_JIRA parameter that accepts either a JIRA ticket key (e.g. `OADP-1234`) or a full URL (e.g. `https://redhat.atlassian.net/browse/OADP-1234`). The value is passed through to artcd `--release-jira` so the shipment MR references the ticket and the ticket gets a web link back to the MR.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED