### PR TITLE
Add GitHub App credentials to seed-lockfile job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -107,6 +107,8 @@ node {
             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
             string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
             string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+            string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
+            file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
             string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
             file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),

--- a/jobs/build/seed-lockfile/Jenkinsfile
+++ b/jobs/build/seed-lockfile/Jenkinsfile
@@ -149,6 +149,8 @@ node {
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                     string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                     string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                    string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
+                    file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     // redis not needed -- this pipeline runs without locks
                     file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),


### PR DESCRIPTION
## Summary

Bind Jenkins credentials `openshift-art-build-bot-app-id` and `openshift-art-build-bot-private-key.pem` in the seed-lockfile job so `artcd seed-lockfile` receives `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_PATH`, consistent with other Konflux pipelines.

## Testing

- [ ] Jenkins credential IDs exist on the controller (same as other build jobs).

Made with [Cursor](https://cursor.com)