### PR TITLE
Add quay.io dev registry login to build-sync-multi

### DIFF
--- a/jobs/build/build-sync-multi/Jenkinsfile
+++ b/jobs/build/build-sync-multi/Jenkinsfile
@@ -173,6 +173,7 @@ node() {
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
                 ]) {
+                    buildlib.registry_quay_dev_login(env.KONFLUX_ART_IMAGES_AUTH_FILE)
                     def envVars = ["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]
                     if (params.TELEMETRY_ENABLED) {
                         envVars << "TELEMETRY_ENABLED=1"


### PR DESCRIPTION
## Summary
- `manifest-tool` fails with `401 Unauthorized` in `build-sync-multi` because `KONFLUX_ART_IMAGES_AUTH_FILE` does not include quay.io dev registry credentials
- Add `buildlib.registry_quay_dev_login(env.KONFLUX_ART_IMAGES_AUTH_FILE)` to merge the quay.io dev credentials into the auth file before running doozer, matching the pattern used in `sync-ci-images`

## Test plan
- [ ] Verify `build-sync-multi` job no longer fails with `manifest-tool` 401 Unauthorized

Made with [Cursor](https://cursor.com)