### PR TITLE
ART-14907: seed-lockfile: add JIRA_KEY parameter

### DIFF
--- a/jobs/build/seed-lockfile/Jenkinsfile
+++ b/jobs/build/seed-lockfile/Jenkinsfile
@@ -82,6 +82,12 @@ node {
                         defaultValue: 'auto',
                         trim: true,
                     ),
+                    string(
+                        name: 'JIRA_KEY',
+                        description: '(Optional) Jira ticket key to include in build title (e.g. ART-14902)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
                 ]
             ],
         ]
@@ -135,6 +141,9 @@ node {
             }
             if (params.BUILD_PRIORITY) {
                 cmd << "--build-priority=${params.BUILD_PRIORITY}"
+            }
+            if (params.JIRA_KEY) {
+                cmd << "--jira-key=${params.JIRA_KEY}"
             }
 
             wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
## Summary

- Add `JIRA_KEY` string parameter to the seed-lockfile Jenkinsfile
- Pass `--jira-key` to the `artcd` command when set

Companion PR: https://github.com/openshift-eng/art-tools/pull/2742 (Python-side implementation)

## Test plan

- [ ] Trigger seed-lockfile with `JIRA_KEY=ART-XXXXX` and verify it's passed through and appears in the build title