### PR TITLE
Standardize auth file vars

### DIFF
--- a/jobs/build/build-sync-konflux/Jenkinsfile
+++ b/jobs/build/build-sync-konflux/Jenkinsfile
@@ -221,7 +221,7 @@ node() {
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
+                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'QUAY_AUTH_FILE'),
                 ]) {
                     def envVars = ["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]
                     if (params.TELEMETRY_ENABLED) {

--- a/jobs/build/build-sync-multi/Jenkinsfile
+++ b/jobs/build/build-sync-multi/Jenkinsfile
@@ -172,7 +172,7 @@ node() {
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
+                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'QUAY_AUTH_FILE'),
                 ]) {
                     def envVars = ["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]
                     if (params.TELEMETRY_ENABLED) {

--- a/jobs/build/build-sync/Jenkinsfile
+++ b/jobs/build/build-sync/Jenkinsfile
@@ -214,7 +214,7 @@ node() {
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'KONFLUX_ART_IMAGES_AUTH_FILE'),
+                    file(credentialsId: 'konflux-art-images-auth-file', variable: 'QUAY_AUTH_FILE'),
                 ]) {
                     withEnv(["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
                         sh(script: cmd.join(' '), returnStdout: true)

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -191,6 +191,7 @@ node {
                              string(credentialsId: 'signing_rekor_url', variable: 'REKOR_URL'),
                              string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                              file(credentialsId: "art-cluster-art-cd-pipeline-kubeconfig", variable: 'ART_CLUSTER_ART_CD_PIPELINE_KUBECONFIG'),
+                             file(credentialsId: 'konflux-art-images-auth-file', variable: 'QUAY_AUTH_FILE'),
                              string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
                             ]) {
                 withEnv(["BUILD_URL=${BUILD_URL}"]) {


### PR DESCRIPTION
Re: https://github.com/openshift-eng/art-tools/pull/2774

Fixed Jenkins wiring so the relevant jobs expose the registry auth file under QUAY_AUTH_FILE:
- build-sync
- build-sync-konflux
- build-sync-multi
- promote-assembly


rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED