### PR TITLE
Serialize low-priority ocp4-scan-konflux and add 4.23 to low priority

### DIFF
--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.hp
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.hp
@@ -29,8 +29,8 @@ node {
             "schedule-ocp4-scan-konflux"
         ]
         for ( version in commonlib.ocpMajorVersions["4plus"] ) {
-            // Only build OCP versions >= 4.18 (includes 4.18+ and 5.0)
-            if (buildlib.cmp_version(version, "4.18") >= 0) {
+            // High priority: versions >= 4.18, excluding 4.23 (low priority for now)
+            if (buildlib.cmp_version(version, "4.18") >= 0 && version != "4.23") {
                 cmd << "--version=${version}"
             }
         }

--- a/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.lp
+++ b/scheduled-jobs/build/ocp4_scan_konflux/Jenkinsfile.lp
@@ -29,11 +29,12 @@ node {
             "schedule-ocp4-scan-konflux"
         ]
         for ( version in commonlib.ocpMajorVersions["4plus"] ) {
-            // Only build OCP versions < 4.18
-            if (buildlib.cmp_version(version, "4.18") == -1) {
+            // Low priority: versions < 4.18 plus 4.23
+            if (buildlib.cmp_version(version, "4.18") == -1 || version == "4.23") {
                 cmd << "--version=${version}"
             }
         }
+        cmd << "--serial"
 
         withCredentials([
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),


### PR DESCRIPTION
## Summary
- Pass `--serial` in the low-priority scan scheduler so scans run sequentially instead of bursting all PLRs at once
- Move 4.23 from high priority to low priority
- Depends on the art-tools PR adding `--serial` support

[ART-15917](https://issues.redhat.com/browse/ART-15917)

## Test plan
- [ ] Verify low-priority scheduled job includes 4.23 and passes `--serial`
- [ ] Verify high-priority scheduled job excludes 4.23 and remains parallel

Made with [Cursor](https://cursor.com)