### PR TITLE
[ART-15994] Fix BUILD_VERSION parameter to support golang builders

### DIFF
--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -134,8 +134,8 @@ node() {
             
             dir(doozer_working) {
                 withCredentials([
-                    string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),

--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -30,7 +30,12 @@ node() {
             parameterDefinitions: [
                 commonlib.suppressEmailParam(),
                 commonlib.mockParam(),
-                commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                string(
+                    name: 'BUILD_VERSION',
+                    description: 'Build group name (e.g., openshift-5.0 for OCP or rhel-9-golang-1.24 for golang builders)',
+                    defaultValue: "openshift-5.0",
+                    trim: true,
+                ),
                 commonlib.artToolsParam(),
                 string(
                     name: 'ASSEMBLY',
@@ -104,7 +109,7 @@ node() {
         try {
             def cmd = [
                 "doozer",
-                "--group", "openshift-${params.BUILD_VERSION}",
+                "--group", "${params.BUILD_VERSION}",
                 "--assembly", "${params.ASSEMBLY}"
             ]
             


### PR DESCRIPTION
## Problem
Base-image-release job only accepts OCP version format for BUILD_VERSION (e.g., "4.18"), but golang builder images require RHEL group names (e.g., "rhel-9-golang-1.24"). This prevents golang builders from using the base image release workflow.

## Solution  
Replace restrictive ocpVersionParam with flexible string parameter that accepts any build group name format.

## Changes
- Replace `commonlib.ocpVersionParam('BUILD_VERSION', '4')` with manual string parameter
- Remove "openshift-" prefix from doozer group parameter construction
- Set default to "openshift-5.0" for OCP builds
- Allow golang builders like "rhel-9-golang-1.24" to work properly

## Impact
- ✅ Golang builder base image workflow now functional
- ✅ Manual base image releases possible for golang builders  
- ✅ Unblocks automated golang builder release pipeline

## Testing
Validated on test job: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/lgarciaa/job/build%252Fbase-image-release/17/

Related: [ART-15994](https://redhat.atlassian.net/browse/ART-15994)