### PR TITLE
ART-17448: Add NETWORK_MODE parameter to build/golang-builder job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -78,6 +78,16 @@ node {
                         description: 'Use golang RPMs from external repos (not tagged in rhaos build tags). Skips tagging and availability checks.',
                         defaultValue: false,
                     ),
+                    choice(
+                        name: 'NETWORK_MODE',
+                        description: 'Override network mode for Konflux builds',
+                        choices: [
+                            "",
+                            "hermetic",
+                            "internal-only",
+                            "open"
+                        ].join("\n")
+                    ),
                     commonlib.mockParam(),
                     commonlib.dryrunParam(),
                     commonlib.artToolsParam(),
@@ -165,6 +175,9 @@ node {
                     }
                     if (params.EXTERNAL_GOLANG_RPMS) {
                         cmd << "--external-golang-rpms"
+                    }
+                    if (params.NETWORK_MODE && params.NETWORK_MODE != "") {
+                        cmd << "--network-mode=${params.NETWORK_MODE}"
                     }
 
                     // Run pipeline


### PR DESCRIPTION
## Summary

- Add `NETWORK_MODE` choice parameter to the `build/golang-builder` Jenkinsfile (choices: empty, `hermetic`, `internal-only`, `open`)
- When set, passes `--network-mode=<value>` to `artcd update-golang`
- Matches the pattern already used by `ocp4-konflux` and `layered-products` jobs

## Motivation

When `group.yml` on a golang branch specifies `konflux.network_mode: hermetic` but no RPM lockfiles exist yet (e.g. for a brand-new Go version like 1.26), the Konflux prefetch job fails. This parameter allows overriding to `open` mode to bypass hermetic prefetch requirements.

## Companion PR

- art-tools: https://github.com/openshift-eng/art-tools/pull/2802

## Test plan

- [ ] Trigger `build/golang-builder` with `NETWORK_MODE=open` for Go 1.26 on openshift-5.0
- [ ] Verify Konflux build succeeds without prefetch

Made with [Cursor](https://cursor.com)