### PR TITLE
poll-payload: Set propagate: false for publish-rpms build steps

### DIFF
--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -1,3 +1,4 @@
+
 node {
     timestamps {
     checkout scm

--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -59,6 +59,7 @@ def publishRPMsEl9(String releaseStream, Map latestRelease, Map previousRelease)
     def arch = commonlib.extractArchFromReleaseName(latestRelease.name)
     build(
         job: '/aos-cd-builds/build%2Fpublish-rpms',
+        propagate: false,
         parameters: [
             string(name: 'BUILD_VERSION', value: buildVersion),
             string(name: 'ARCH', value: arch),
@@ -72,6 +73,7 @@ def publishRPMsEl8(String releaseStream, Map latestRelease, Map previousRelease)
     def arch = commonlib.extractArchFromReleaseName(latestRelease.name)
     build(
         job: '/aos-cd-builds/build%2Fpublish-rpms',
+        propagate: false,
         parameters: [
             string(name: 'BUILD_VERSION', value: buildVersion),
             string(name: 'ARCH', value: arch),


### PR DESCRIPTION
## Summary
- Add `propagate: false` to the `publishRPMsEl9` and `publishRPMsEl8` build steps in poll-payload
- Prevents publish-rpms failures from failing the entire poll-payload job, consistent with the other build steps (`startRhcosSyncJob`, `startBuildMicroshiftJob`)

## Test plan
- [ ] Verify poll-payload job continues when a publish-rpms child build fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)