### PR TITLE
ART-14263: Sync client symlink directories to Cloudflare R2

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -76,6 +76,14 @@ function transferClientIfNeeded() {
         rclone sync -c "${S3_SRC}" "${S3_DEST}"  # Run sync to delete any files that should no longer be present.
         # CloudFront will cache files of the same name (e.g. sha256sum.txt), so we need to explicitly invalidate
         aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "/${S3_DEST_PATH}*"
+
+        # Mirror to Cloudflare R2: sync from source release dir to symlink dir on R2.
+        # Uses aws s3 sync (not rclone) since R2 credentials are configured via aws profile.
+        # --exact-timestamps ensures files are compared by mtime, --delete removes stale files
+        # to match the rclone sync behavior above, keeping R2 in parity with S3.
+        aws s3 sync "s3://art-srv-enterprise/${S3_SRC_PATH}" "s3://art-srv-enterprise/${S3_DEST_PATH}" \
+            --no-progress --exact-timestamps --delete \
+            --profile cloudflare --endpoint-url ${CLOUDFLARE_ENDPOINT}
     fi
 
     # Remove the rendered rclone config file


### PR DESCRIPTION
## Summary

The `set_client_latest` job creates `stable/`, `latest/`, `fast/`, and `candidate/` directories for OCP clients on S3, but these were not being mirrored to Cloudflare R2. This causes 404 errors when CI jobs attempt to use the R2-backed mirror endpoint for these paths (e.g., `/pub/openshift-v4/x86_64/clients/ocp/stable/`).

This PR adds `aws s3 sync` to Cloudflare R2 in the `transferClientIfNeeded` function, using the same pattern as other R2-syncing code in ART pipelines.

## Changes

- Added Cloudflare R2 sync after the existing S3 sync in `transferClientIfNeeded`
- Uses `--profile cloudflare --endpoint-url ${CLOUDFLARE_ENDPOINT}` (already exposed in Jenkinsfile)

## Testing

After merging:
1. Trigger `set_client_latest` job for a known release
2. Verify the stable/latest directories exist on R2:
   ```bash
   curl -I https://openshift-mirror-list.ci-systems.workers.dev/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
   ```

Fixes: https://issues.redhat.com/browse/ART-14263
