### PR TITLE
Move R2 sync outside S3 check and add idempotency

### DIFF
--- a/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
+++ b/jobs/build/set_client_latest/S3-set-v4-client-latest.sh
@@ -76,14 +76,20 @@ function transferClientIfNeeded() {
         rclone sync -c "${S3_SRC}" "${S3_DEST}"  # Run sync to delete any files that should no longer be present.
         # CloudFront will cache files of the same name (e.g. sha256sum.txt), so we need to explicitly invalidate
         aws cloudfront create-invalidation --distribution-id E3RAW1IMLSZJW3 --paths "/${S3_DEST_PATH}*"
+    fi
 
-        # Mirror to Cloudflare R2: sync from source release dir to symlink dir on R2.
-        # Uses aws s3 sync (not rclone) since R2 credentials are configured via aws profile.
-        # --exact-timestamps ensures files are compared by mtime, --delete removes stale files
-        # to match the rclone sync behavior above, keeping R2 in parity with S3.
-        aws s3 sync "s3://art-srv-enterprise/${S3_SRC_PATH}" "s3://art-srv-enterprise/${S3_DEST_PATH}" \
-            --no-progress --exact-timestamps --delete \
-            --profile cloudflare --endpoint-url ${CLOUDFLARE_ENDPOINT}
+    # Mirror to Cloudflare R2: sync from source release dir to symlink dir on R2.
+    # Uses aws s3 sync (not rclone) since R2 credentials are configured via aws profile.
+    # --exact-timestamps ensures files are compared by mtime, --delete removes stale files
+    # to match the rclone sync behavior above, keeping R2 in parity with S3.
+    # Runs outside the S3 check since R2 may be behind even when S3 is in sync.
+    # First check if R2 needs syncing using --dryrun to avoid unnecessary API calls.
+    R2_SYNC_CMD="aws s3 sync s3://art-srv-enterprise/${S3_SRC_PATH} s3://art-srv-enterprise/${S3_DEST_PATH} --exact-timestamps --delete --profile cloudflare --endpoint-url ${CLOUDFLARE_ENDPOINT}"
+    if [[ -n "$(${R2_SYNC_CMD} --dryrun 2>&1)" ]] || [[ "${FORCE_UPDATE}" == "1" ]]; then
+        echo "R2 sync needed, syncing to Cloudflare R2..."
+        ${R2_SYNC_CMD} --no-progress
+    else
+        echo "R2 already in sync, skipping"
     fi
 
     # Remove the rendered rclone config file


### PR DESCRIPTION
## Summary

Follow-up to #4663. The previous PR synced R2 only when S3 needed updating, but R2 may be behind even when S3 is already in sync (as seen in the Jenkins logs showing "0 differences found").

This PR:
1. Moves the R2 sync **outside** the S3 check block so it always runs
2. Adds a `--dryrun` check before syncing to avoid unnecessary API calls when R2 is already in sync
3. Respects the `FORCE_UPDATE` flag

## Changes

```bash
# Sync to Cloudflare R2 to ensure parity (runs outside the S3 check since R2 may be behind).
# First check if R2 needs syncing using --dryrun to avoid unnecessary API calls.
R2_SYNC_CMD="aws s3 sync s3://... --profile cloudflare --endpoint-url ${CLOUDFLARE_ENDPOINT}"
if [[ -n "$(${R2_SYNC_CMD} --dryrun 2>&1)" ]] || [[ "${FORCE_UPDATE}" == "1" ]]; then
    echo "R2 sync needed, syncing to Cloudflare R2..."
    ${R2_SYNC_CMD} --no-progress
else
    echo "R2 already in sync, skipping"
fi
```

## Testing

After merging, the next scheduled `set_cincinnati_links` run will sync R2 for all channels/versions that are behind.

Fixes: https://issues.redhat.com/browse/ART-14263
