### PR TITLE
ART-18058: Restrict /approve in OWNERS to senior team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,8 @@
 reviewers:
-- sosiouxme
 - jupierce
-- thiagoalessio
 - joepvd
 - thegreyd
-- vfreex
 - locriandev
-- Ximinhan
 - ashwindasr
 - mbiarnes
 - rayfordj
@@ -15,20 +11,15 @@ reviewers:
 - fgallott
 - fbladilo
 approvers:
-- sosiouxme
 - jupierce
-- thiagoalessio
 - joepvd
 - thegreyd
-- vfreex
 - locriandev
-- Ximinhan
 - ashwindasr
-- mbiarnes
-- rayfordj
-- lgarciaaco
-- adobes1
-- fgallott
-- fbladilo
+emeritus_approvers:
+- sosiouxme
+- thiagoalessio
+- vfreex
+- Ximinhan
 # this is to keep automation from complaining about ownership of base image builds
 component: Release


### PR DESCRIPTION
## Summary

- Restrict the `approvers` list in OWNERS to 5 senior team members (jupierce, joepvd, thegreyd, locriandev, ashwindasr) to prevent premature approvals that bypass proper gating
- Keep all active team members as `reviewers` so anyone can still review code

Jira: https://redhat.atlassian.net/browse/ART-18058

Made with [Cursor](https://cursor.com)