### PR TITLE
Enable OKD 4.23

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -29,6 +29,7 @@ ocp5Versions = [
 
 okdVersions = [
     "5.0",
+    "4.23",
     "4.22",
     "4.21",
 ]


### PR DESCRIPTION
Add 4.23 back to the okdVersions list to enable OKD builds for version 4.23.