### PR TITLE
Remove ci-deps reposync from sync-for-ci

### DIFF
--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -70,7 +70,6 @@ node() {
             if ( version == sortedVersions()[-1] ) {
                 def (major, minor) = commonlib.extractMajorMinorVersionNumbers(version)
                 runFor(group, "${major}.${minor+1}", arch)
-                runFor('ci-deps', 'ci-deps', 'x86_64')
             }
         }
     }


### PR DESCRIPTION
## Summary
- Stop looking at the `ci-deps` branch in the scheduled sync-for-ci job, as it is no longer needed.

## Test plan
- [ ] Verify scheduled sync-for-ci job runs without errors after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)