### PR TITLE
golang-builder: provide registry.redhat.io auth file

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -122,6 +122,7 @@ node {
                 string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                 file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                 file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                file(credentialsId: 'creds_registry.redhat.io', variable: 'REGISTRY_AUTH_FILE'),
             ]) {
                 withEnv(["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
                     script {


### PR DESCRIPTION
## Summary
- bind the `creds_registry.redhat.io` Jenkins credential in the `golang-builder` job
- expose it as `REGISTRY_AUTH_FILE` so `artcd update-golang` can read the published builder registry auth file

## Test plan
- not run (Jenkinsfile-only change)

Made with [Cursor](https://cursor.com)