### PR TITLE
Fix parameter syntax in syncRepoToS3Mirror call

### DIFF
--- a/jobs/build/sync-for-ci/Jenkinsfile
+++ b/jobs/build/sync-for-ci/Jenkinsfile
@@ -141,7 +141,7 @@ node {
                      * Instead, pay the relatively minor storage costs for reposync indefinitely. ART can
                      * clean up old directories when they are EOL.
                      */
-                    commonlib.syncRepoToS3Mirror("${LOCAL_SYNC_DIR}/", "${S3_SYNC_DIR}/", remove_old=false, dry_run=params.DRY_RUN)
+                    commonlib.syncRepoToS3Mirror("${LOCAL_SYNC_DIR}/", "${S3_SYNC_DIR}/", remove_old: false, dry_run: params.DRY_RUN)
                 }
             }
         }


### PR DESCRIPTION
https://github.com/openshift-eng/aos-cd-jobs/pull/4674 broke the sync-for-ci job

example: https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fsync-for-ci/298526/console

doc: https://docs.groovy-lang.org/latest/html/documentation/#_mixing_named_and_positional_parameters