### PR TITLE
Fix syncRepoToS3Mirror to use positional parameters

### DIFF
--- a/jobs/build/sync-for-ci/Jenkinsfile
+++ b/jobs/build/sync-for-ci/Jenkinsfile
@@ -141,7 +141,7 @@ node {
                      * Instead, pay the relatively minor storage costs for reposync indefinitely. ART can
                      * clean up old directories when they are EOL.
                      */
-                    commonlib.syncRepoToS3Mirror("${LOCAL_SYNC_DIR}/", "${S3_SYNC_DIR}/", remove_old: false, dry_run: params.DRY_RUN)
+                    commonlib.syncRepoToS3Mirror("${LOCAL_SYNC_DIR}/", "${S3_SYNC_DIR}/", false, 60, true, params.DRY_RUN)
                 }
             }
         }


### PR DESCRIPTION
PR #4676 attempted to fix the parameter syntax by changing `=` to `:`, but this created a new issue: Groovy interpreted `remove_old: false, dry_run: params.DRY_RUN` as a Map literal `[remove_old:false, dry_run:false]` which was passed as the third positional parameter, causing the AWS CLI command to fail with "Unknown options".

The `syncRepoToS3Mirror` function uses positional parameters with defaults, not named parameters. This PR fixes the call to use positional parameters consistently with the rest of the codebase (see `jobs/build/microshift_sync/Jenkinsfile` for similar usage).

**Changes:**
- Updated the call to pass all 6 parameters positionally: `local_dir`, `s3_path`, `remove_old=false`, `timeout_minutes=60`, `issue_cloudfront_invalidation=true`, `dry_run=params.DRY_RUN`

Fixes the sync-for-ci job that was broken by #4676.