### PR TITLE
ART-18307 build-microshift-bootc: add FORCE_OPEN_BUILD parameter

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -64,6 +64,11 @@ node() {
                             trim: true,
                         ),
                         booleanParam(
+                            name: "FORCE_OPEN_BUILD",
+                            description: "Force redo of open build phase even if one already exists for the assembly",
+                            defaultValue: false
+                        ),
+                        booleanParam(
                             name: 'IGNORE_LOCKS',
                             description: 'Do not wait for other builds in this version to complete (use only if you know they will not conflict)',
                             defaultValue: false
@@ -117,6 +122,9 @@ node() {
                 }
                 if (params.FORCE_PLASHET_SYNC) {
                     cmd << "--force-plashet-sync"
+                }
+                if (params.FORCE_OPEN_BUILD) {
+                    cmd << "--force-open-build"
                 }
                 withCredentials([
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),


### PR DESCRIPTION
## Summary
- Adds `FORCE_OPEN_BUILD` Jenkins parameter to force a redo of the open build phase when stale
- Companion to openshift-eng/art-tools#2860 which implements the two-phase build (open → hermetic) in the pipeline

## Test plan
- [ ] Trigger build-microshift-bootc with default params (FORCE_OPEN_BUILD=false)
- [ ] Verify FORCE_OPEN_BUILD=true forces the open build phase