### PR TITLE
ART-14770 Add jira secret credential to ocp4-scan-konflux job

### DIFF
--- a/jobs/build/ocp4-scan-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-scan-konflux/Jenkinsfile
@@ -114,6 +114,7 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                             file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                             file(credentialsId: 'creds_registry.redhat.io', variable: 'KONFLUX_OPERATOR_INDEX_AUTH_FILE'),
+                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                         ]) {
                         // There is a vanishingly small race condition here, but it is not dangerous;
                         // it can only lead to undesired delays (i.e. waiting to scan while a build is ongoing).


### PR DESCRIPTION
Needed for https://github.com/openshift-eng/art-tools/pull/2684

## Summary
- Add `jboss-jira-token` credential (as `JIRA_TOKEN` env var) to the `ocp4-scan-konflux` job's `withCredentials` block, matching the pattern used in the `ocp4` build job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)