### PR TITLE
Add GITLAB_TOKEN credential to build-microshift pipeline

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -129,6 +129,7 @@ node() {
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                    string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
                 ]) {
                     echo "Will run ${cmd.join(' ')}"
                     buildlib.withAppCiAsArtPublish() {


### PR DESCRIPTION
## Summary
- `elliott find-bugs:sweep` now unconditionally fetches Konflux shipment builds for bug categorization (openshift-eng/art-tools@6f5ad6248), which requires GitLab access via `GITLAB_TOKEN`
- `build-microshift` was missing this credential, causing the pipeline to fail at the bug sweep stage with `ValueError: GITLAB_TOKEN environment variable is required for Konflux operations`
- Other pipelines (`build-microshift-bootc`, `promote-assembly`, `build-fbc`) already include this credential

## Failed build
https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Fbuild-microshift/3803/console