### PR TITLE
Add MTC Konflux kubeconfig to base-image-release job

### DIFF
--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -140,7 +140,12 @@ node() {
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-oadp-konflux-service-account', variable: 'OADP_KONFLUX_SA_KUBECONFIG'),
                     file(credentialsId: 'openshift-bot-mtc-konflux-service-account', variable: 'MTC_KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-mta-konflux-service-account', variable: 'MTA_KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-logging-konflux-service-account', variable: 'LOGGING_KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-acm-konflux-service-account', variable: 'ACM_KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-oap-konflux-service-account', variable: 'OAP_KONFLUX_SA_KUBECONFIG'),
                     file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                     usernamePassword(
                         credentialsId: 'art-dash-db-login',

--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -140,6 +140,7 @@ node() {
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'openshift-bot-mtc-konflux-service-account', variable: 'MTC_KONFLUX_SA_KUBECONFIG'),
                     file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                     usernamePassword(
                         credentialsId: 'art-dash-db-login',


### PR DESCRIPTION
## Summary
Adds the MTC Konflux service-account kubeconfig credential to the `base-image-release` Jenkins job so `MTC_KONFLUX_SA_KUBECONFIG` is available to Doozer during `images:release-to-base-repo`, consistent with jobs such as `build-fbc` and `olm_bundle_konflux`.

## Changes
- `jobs/build/base-image-release/Jenkinsfile`: `withCredentials` file binding for `openshift-bot-mtc-konflux-service-account` → `MTC_KONFLUX_SA_KUBECONFIG`