### PR TITLE
feat(ocp4-konflux): add SKIP_EC_VERIFY parameter

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -121,6 +121,11 @@ node {
                         description: '(For testing) Skip the OLM bundle build step',
                         defaultValue: false,  // Default to true until we believe bundle build is stable.
                     ),
+                    booleanParam(
+                        name: 'SKIP_EC_VERIFY',
+                        description: 'Skip Enterprise Contract verification for built images',
+                        defaultValue: false,
+                    ),
                     choice(
                         name: 'NETWORK_MODE',
                         description: 'Override network mode for Konflux builds',
@@ -195,6 +200,9 @@ node {
             }
             if (params.SKIP_BUNDLE_BUILD) {
                 cmd << "--skip-bundle-build"
+            }
+            if (params.SKIP_EC_VERIFY) {
+                cmd << "--skip-ec-verify"
             }
             if (params.NETWORK_MODE && params.NETWORK_MODE != "") {
                 cmd << "--skip-build-sync-konflux"


### PR DESCRIPTION
## Summary
- Add `SKIP_EC_VERIFY` boolean parameter (default: `false`) to the ocp4-konflux Jenkins job
- Controls whether Enterprise Contract verification runs for built images

## Changes
- Add `SKIP_EC_VERIFY` parameter to Jenkins parameterDefinitions
- Wire parameter to pass `--skip-ec-verify` flag to artcd command when enabled

## Context
This is a follow-up to art-tools changes that made EC verification opt-out rather than automatically skipped for test assemblies. Operators can now explicitly choose to skip EC validation when needed, rather than it being automatically disabled based on assembly name.

## Related
- Companion PR in art-tools: https://github.com/openshift-eng/art-tools/pull/2895

🤖 Generated with [Claude Code](https://claude.com/claude-code)