### PR TITLE
Add MAJOR_BUMP parameter to golang-builder job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -78,6 +78,11 @@ node {
                         description: 'Use golang RPMs from external repos (not tagged in rhaos build tags). Skips tagging and availability checks.',
                         defaultValue: false,
                     ),
+                    booleanParam(
+                        name: 'MAJOR_BUMP',
+                        description: 'Indicates a major.minor golang version bump (e.g. 1.22 -> 1.23). Permits validation of go_latest even when the new version does not match current group.yml vars.',
+                        defaultValue: false,
+                    ),
                     choice(
                         name: 'NETWORK_MODE',
                         description: 'Override network mode for Konflux builds',
@@ -176,6 +181,9 @@ node {
                         }
                         if (params.EXTERNAL_GOLANG_RPMS) {
                             cmd << "--external-golang-rpms"
+                        }
+                        if (params.MAJOR_BUMP) {
+                            cmd << "--major-bump"
                         }
                         if (params.NETWORK_MODE && params.NETWORK_MODE != "") {
                             cmd << "--network-mode=${params.NETWORK_MODE}"


### PR DESCRIPTION
## Summary
- Adds `MAJOR_BUMP` boolean parameter to the golang-builder Jenkins job
- When checked, passes `--major-bump` flag to `artcd update-golang`
- Companion to https://github.com/openshift-eng/art-tools/pull/2909 which adds the flag to pyartcd

## Test plan
- [ ] Trigger golang-builder job with `MAJOR_BUMP` checked and verify `--major-bump` appears in the artcd command
- [ ] Trigger without `MAJOR_BUMP` and verify flag is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)