### PR TITLE
Fix 'def keyword' warnings in pipeline scripts with @Field annotation

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -1,13 +1,14 @@
 #!/usr/bin/groovy
 import java.net.URLEncoder
+import groovy.transform.Field
 
-commonlib = load("pipeline-scripts/commonlib.groovy")
+@Field commonlib = load("pipeline-scripts/commonlib.groovy")
 commonlib.initialize()
-slacklib = commonlib.slacklib
+@Field slacklib = commonlib.slacklib
 
-GITHUB_URLS = [:]
-GITHUB_BASE_PATHS = [:]
-GITHUB_BASE = "git@github.com:openshift"
+@Field GITHUB_URLS = [:]
+@Field GITHUB_BASE_PATHS = [:]
+@Field GITHUB_BASE = "git@github.com:openshift"
 
 // dump important tool versions to console
 def dump_versions() {
@@ -671,7 +672,7 @@ def cleanWorkspace() {
     }
 }
 
-WORKDIR_COUNTER=0 // ensure workdir cleanup can be invoked multiple times per job
+@Field WORKDIR_COUNTER=0 // ensure workdir cleanup can be invoked multiple times per job
 def cleanWorkdir(workdir, synchronous=false) {
     // get a fresh workdir; removing the old one can be synchronous or background.
 

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -1,12 +1,13 @@
+import groovy.transform.Field
 
-slacklib = load("pipeline-scripts/slacklib.groovy")
+@Field slacklib = load("pipeline-scripts/slacklib.groovy")
 
-ocp3Versions = [
+@Field ocp3Versions = [
     "3.11",
 ]
 
 // All buildable versions of ocp4
-ocp4Versions = [
+@Field ocp4Versions = [
     "4.23",
     "4.22",
     "4.21",
@@ -22,19 +23,19 @@ ocp4Versions = [
 ]
 
 // All buildable versions of ocp5
-ocp5Versions = [
+@Field ocp5Versions = [
     "5.0",
 ]
 
 
-okdVersions = [
+@Field okdVersions = [
     "5.0",
     "4.23",
     "4.22",
     "4.21",
 ]
 
-nonOCPGroups = [
+@Field nonOCPGroups = [
     "logging-6.0",
     "logging-6.2",
     "logging-6.3",
@@ -50,14 +51,14 @@ nonOCPGroups = [
     "oadp-1.6",
 ]
 
-ocpVersions = ocp5Versions + ocp4Versions + ocp3Versions
+@Field ocpVersions = ocp5Versions + ocp4Versions + ocp3Versions
 
 // some of our systems refer to golang's chosen architecture nomenclature;
 // most use brew's nomenclature or similar. translate.
-brewArches = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
-brewArchSuffixes = ["", "-s390x", "-ppc64le", "-aarch64", "-multi"]
-goArches = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
-goArchSuffixes = ["", "-s390x", "-ppc64le", "-arm64", "-multi"]
+@Field brewArches = ["x86_64", "s390x", "ppc64le", "aarch64", "multi"]
+@Field brewArchSuffixes = ["", "-s390x", "-ppc64le", "-aarch64", "-multi"]
+@Field goArches = ["amd64", "s390x", "ppc64le", "arm64", "multi"]
+@Field goArchSuffixes = ["", "-s390x", "-ppc64le", "-arm64", "-multi"]
 def goArchForBrewArch(String brewArch) {
     if (brewArch in goArches) return brewArch  // allow to already be a go arch, just keep same
     if (brewArch in brewArches)
@@ -82,7 +83,7 @@ def goSuffixForArch(String arch) {
     return goArchSuffixes[goArches.findIndexOf {it == arch}]
 }
 
-ocpMajorVersions = [
+@Field ocpMajorVersions = [
     "5": ocp5Versions,
     "4": ocp4Versions,
     "4plus": ocp5Versions + ocp4Versions,
@@ -246,7 +247,7 @@ def buildURL(String append='') {
     env.BUILD_URL.replace('https://buildvm.openshift.eng.bos.redhat.com:8443', 'https://localhost:8888') + append
 }
 
-emailIndex = 0
+@Field emailIndex = 0
 /**
  * Wrapper to persist email as an artifact and enable suppressing actual email
  */
@@ -314,7 +315,7 @@ def safeArchiveArtifacts(List patterns) {
 }
 
 import java.util.concurrent.atomic.AtomicInteger
-shellCounter = new AtomicInteger()
+@Field shellCounter = new AtomicInteger()
 
 @NonCPS
 def getNextShellCounter() {

--- a/pipeline-scripts/slacklib.groovy
+++ b/pipeline-scripts/slacklib.groovy
@@ -1,4 +1,5 @@
 import groovy.json.JsonOutput
+import groovy.transform.Field
 
 /**
  * Example usage:
@@ -27,7 +28,7 @@ import groovy.json.JsonOutput
  */
 
 // Maps builder emails to slack usernames IF email username does not match
-email_to_slack_map = [
+@Field email_to_slack_map = [
     'lmeyer@redhat.com': '@sosiouxme',
     'jdelft@redhat.com': '@joep',
 ]


### PR DESCRIPTION
Script-scope variables in loaded Groovy scripts without `def` or `@Field` cause Jenkins CPS to emit memory leak warnings. Adding `@Field` from groovy.transform.Field declares them as proper class fields, preserving external accessibility (e.g. commonlib.ocp4Versions) while eliminating the warnings.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED