### PR TITLE
Add 5.0 to drop-advisories version param

### DIFF
--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -21,7 +21,7 @@ node {
                 $class: 'ParametersDefinitionProperty',
                 parameterDefinitions: [
                     commonlib.artToolsParam(),
-                    commonlib.ocpVersionParam('VERSION', '4'),
+                    commonlib.ocpVersionParam('VERSION', '4plus'),
                     string(
                         name: 'ADVISORIES',
                         description: 'One or more advisories to drop, comma separated',


### PR DESCRIPTION
## Summary
- Change `ocpVersionParam` major version filter from `'4'` to `'4plus'` in the drop-advisories job
- `'4plus'` includes `ocp5Versions + ocp4Versions`, adding `5.0` to the VERSION dropdown

## Test plan
- Verify the drop-advisories job shows `5.0` as an option in the VERSION parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)