### PR TITLE
Add microshift poll-payload support for 4.23 and 5.0

### DIFF
--- a/scheduled-jobs/build/poll-payload/Jenkinsfile
+++ b/scheduled-jobs/build/poll-payload/Jenkinsfile
@@ -18,6 +18,12 @@ import groovy.json.JsonOutput
     "4-dev-preview-ppc64le": [this.&setDevPreviewLatest],
     "4-dev-preview-arm64": [this.&setDevPreviewLatest],
 
+    "5.0.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8, this.&startRhcosSyncJob],
+    "5.0.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+
+    "4.23.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8, this.&startRhcosSyncJob],
+    "4.23.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
+
     "4.22.0-0.nightly":  [this.&startBuildMicroshiftJob, this.&publishRPMsEl9, this.&publishRPMsEl8, this.&startRhcosSyncJob],
     "4.22.0-0.nightly-arm64": [this.&publishRPMsEl9, this.&publishRPMsEl8],
 


### PR DESCRIPTION
## Summary
- Enable automatic microshift build triggering for OCP 4.23 and 5.0 release streams
- Adds poll-payload ACTIONS entries for 5.0.0-0.nightly and 4.23.0-0.nightly
- Includes both x86_64 (full actions) and arm64 (RPM publish only) variants

## Test plan
- [ ] Verify poll-payload job runs successfully with new version entries
- [ ] Confirm microshift builds trigger when new nightlies are detected for 4.23/5.0
- [ ] Check that RPM publishing works for both EL8 and EL9

🤖 Generated with [Claude Code](https://claude.com/claude-code)