### PR TITLE
build-microshift-bootc: add TRIGGER_OPEN_BUILD_FIRST param

### DIFF
--- a/jobs/build/build-microshift-bootc/Jenkinsfile
+++ b/jobs/build/build-microshift-bootc/Jenkinsfile
@@ -51,6 +51,11 @@ node() {
                             description: "Prepare shipment for microshift-bootc for the assembly",
                             defaultValue: true
                         ),
+                        booleanParam(
+                            name: "TRIGGER_OPEN_BUILD_FIRST",
+                            description: "Run an open build before the hermetic build. Useful when building microshift-bootc for the first time in a given group (e.g. first microshift-bootc in openshift-4.21)",
+                            defaultValue: false
+                        ),
                         string(
                             name: 'DOOZER_DATA_PATH',
                             description: 'ocp-build-data fork to use (e.g. assembly definition in your own fork)',
@@ -117,6 +122,9 @@ node() {
                 }
                 if (params.FORCE_PLASHET_SYNC) {
                     cmd << "--force-plashet-sync"
+                }
+                if (params.TRIGGER_OPEN_BUILD_FIRST) {
+                    cmd << "--trigger-open-build-first"
                 }
                 withCredentials([
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),


### PR DESCRIPTION
## Summary

- Adds a new `TRIGGER_OPEN_BUILD_FIRST` boolean parameter (default: `false`) to the `build-microshift-bootc` Jenkins job
- When enabled, runs an open (non-hermetic) build before the hermetic build; the open build populates the `installed_rpms` DB field that doozer uses for lockfile generation
- Useful when building microshift-bootc for the first time in a new group (e.g. first microshift-bootc in openshift-4.21) where no prior build exists to seed the hermetic lockfile

Requires art-tools change: https://github.com/openshift-eng/art-tools/pull/2934