### PR TITLE
Add DOOZER_DATA_GITREF parameter to build-microshift job

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -58,6 +58,12 @@ node() {
                             defaultValue: "https://github.com/openshift-eng/ocp-build-data",
                             trim: true,
                         ),
+                        string(
+                            name: 'DOOZER_DATA_GITREF',
+                            description: '(Optional) Doozer data path git [branch / tag / sha] to use',
+                            defaultValue: "",
+                            trim: true,
+                        ),
                         booleanParam(
                             name: 'IGNORE_LOCKS',
                             description: 'Do not wait for other builds in this version to complete (use only if you know they will not conflict)',
@@ -106,6 +112,9 @@ node() {
                     "-g", "openshift-$params.BUILD_VERSION",
                     "--assembly", params.ASSEMBLY,
                 ]
+                if (params.DOOZER_DATA_GITREF) {
+                    cmd << "--data-gitref=${params.DOOZER_DATA_GITREF}"
+                }
                 if (params.RELEASE_PAYLOADS) {
                     for (nightly in commonlib.parseList(params.RELEASE_PAYLOADS)) {
                         cmd << "--payload" << nightly.trim()


### PR DESCRIPTION
## Summary
- Add `DOOZER_DATA_GITREF` parameter to build-microshift Jenkins job
- Pass `--data-gitref` to artcd command when parameter is provided

This adds support for specifying a git branch/tag/sha for the ocp-build-data fork, matching the functionality already present in build-microshift-bootc and ocp4-konflux jobs.

## Changes
- Added `DOOZER_DATA_GITREF` string parameter (optional) to Jenkinsfile
- Added conditional logic to pass `--data-gitref` to artcd command

## Test plan
- [ ] Manual test with custom ocp-build-data branch
- [ ] Verify default behavior (no gitref) still works

## Related
- Companion PR in art-tools: https://github.com/openshift-eng/art-tools/pull/2947

🤖 Generated with [Claude Code](https://claude.com/claude-code)