### PR TITLE
Add build-conforma-verify Jenkins job

### DIFF
--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -1,0 +1,143 @@
+#!/usr/bin/env groovy
+
+node {
+    timestamps {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    commonlib.describeJob("build-conforma-verify", """
+        Run Conforma (Enterprise Contract) verification against OCP image builds.
+        Accepts an OCP version and optional list of NVRs. If no NVRs are provided,
+        the latest builds for the assembly are fetched automatically.
+    """)
+
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '30',
+                    daysToKeepStr: '30')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.dryrunParam(),
+                    commonlib.mockParam(),
+                    commonlib.artToolsParam(),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4plus'),
+                    string(
+                        name: 'ASSEMBLY',
+                        description: 'The name of an assembly to verify builds for',
+                        defaultValue: "stream",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'BUILD_LIST',
+                        description: '(Optional) Comma-separated list of NVRs to verify. If empty, latest builds for the assembly are fetched via elliott find-builds',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'DOOZER_DATA_PATH',
+                        description: 'ocp-build-data fork to use (e.g. test customizations on your own fork)',
+                        defaultValue: "https://github.com/openshift-eng/ocp-build-data",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'DOOZER_DATA_GITREF',
+                        description: '(Optional) Doozer data path git [branch / tag / sha] to use',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    choice(
+                        name: 'ENV',
+                        description: 'Environment whose EC policy to verify against',
+                        choices: [
+                            "prod",
+                            "stage",
+                        ].join("\n")
+                    ),
+                    string(
+                        name: 'BATCH_SIZE',
+                        description: 'Number of NVRs to process in each verification batch',
+                        defaultValue: "10",
+                        trim: true,
+                    ),
+                    booleanParam(
+                        name: 'FAIL_FAST',
+                        description: 'Stop processing immediately if any NVR fails verification',
+                        defaultValue: false,
+                    ),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    if (currentBuild.description == null) {
+        currentBuild.description = ""
+    }
+    sshagent(["openshift-bot"]) {
+        stage("initialize") {
+            currentBuild.displayName = "#${currentBuild.number}"
+        }
+
+        stage("conforma-verify") {
+            def cmd = [
+                "artcd",
+                "-v",
+                "--working-dir=./artcd_working",
+                "--config=./config/artcd.toml",
+            ]
+            if (params.DRY_RUN) {
+                cmd << "--dry-run"
+            }
+            cmd += [
+                "build-conforma-verify",
+                "--version=${params.BUILD_VERSION}",
+                "--assembly=${params.ASSEMBLY}",
+                "--env=${params.ENV}",
+                "--batch-size=${params.BATCH_SIZE}",
+            ]
+            if (params.DOOZER_DATA_PATH) {
+                cmd << "--data-path=${params.DOOZER_DATA_PATH}"
+            }
+            if (params.DOOZER_DATA_GITREF) {
+                cmd << "--data-gitref=${params.DOOZER_DATA_GITREF}"
+            }
+            if (params.BUILD_LIST) {
+                cmd << "--builds=${commonlib.cleanCommaList(params.BUILD_LIST)}"
+            }
+            if (params.FAIL_FAST) {
+                cmd << "--fail-fast"
+            }
+
+            buildlib.withAppCiAsArtPublish() {
+                withCredentials([
+                    file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
+                    string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                    file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                    file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                ]) {
+                    withEnv(["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']) {
+                        buildlib.init_artcd_working_dir()
+                        sh(script: cmd.join(' '), returnStdout: true)
+                    }
+                }
+            }
+        }
+
+        stage("terminate") {
+            commonlib.safeArchiveArtifacts([
+                "artcd_working/**/*.log",
+                "artcd_working/**/*.yaml",
+                "artcd_working/**/*.yml",
+                "artcd_working/**/results.yaml",
+            ])
+            buildlib.cleanWorkspace()
+        }
+    }
+    }
+}

--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -50,20 +50,6 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
-                    choice(
-                        name: 'ENV',
-                        description: 'Environment whose EC policy to verify against',
-                        choices: [
-                            "prod",
-                            "stage",
-                        ].join("\n")
-                    ),
-                    string(
-                        name: 'BATCH_SIZE',
-                        description: 'Number of NVRs to process in each verification batch',
-                        defaultValue: "10",
-                        trim: true,
-                    ),
                     booleanParam(
                         name: 'FAIL_FAST',
                         description: 'Stop processing immediately if any NVR fails verification',
@@ -98,8 +84,6 @@ node {
                 "build-conforma-verify",
                 "--version=${params.BUILD_VERSION}",
                 "--assembly=${params.ASSEMBLY}",
-                "--env=${params.ENV}",
-                "--batch-size=${params.BATCH_SIZE}",
             ]
             if (params.DOOZER_DATA_PATH) {
                 cmd << "--data-path=${params.DOOZER_DATA_PATH}"


### PR DESCRIPTION
## Summary
- New Jenkins job `build-conforma-verify` to run Conforma (Enterprise Contract) verification against OCP image builds
- Accepts an OCP version and optional comma-separated list of NVRs
- When no NVRs are provided, latest builds for the assembly are fetched automatically via `elliott find-builds`
- Pairs with the art-tools PR that adds the `build-conforma-verify` artcd pipeline

## Test plan
- [ ] Verify Jenkinsfile parameters render correctly in Jenkins UI
- [ ] Run with explicit NVRs against test assembly
- [ ] Run without NVRs to test auto-discovery of latest builds

Made with [Cursor](https://cursor.com)