### PR TITLE
Remove FAIL_FAST param from build-conforma-verify

### DIFF
--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -50,11 +50,6 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
-                    booleanParam(
-                        name: 'FAIL_FAST',
-                        description: 'Stop processing immediately if any NVR fails verification',
-                        defaultValue: false,
-                    ),
                 ]
             ],
         ]
@@ -93,9 +88,6 @@ node {
             }
             if (params.BUILD_LIST) {
                 cmd << "--builds=${commonlib.cleanCommaList(params.BUILD_LIST)}"
-            }
-            if (params.FAIL_FAST) {
-                cmd << "--fail-fast"
             }
 
             buildlib.withAppCiAsArtPublish() {


### PR DESCRIPTION
## Summary
- Removes the `FAIL_FAST` parameter and `--fail-fast` flag from the build-conforma-verify Jenkinsfile
- EC verification now runs as a single PipelineRun with all components in one multi-component Snapshot, so per-NVR fail-fast no longer applies
- Companion to art-tools PR that switches to single-snapshot EC verification

## Test plan
- [ ] Run build-conforma-verify job and confirm it works without FAIL_FAST param

Made with [Cursor](https://cursor.com)