### PR TITLE
Prefix OCP version in build-conforma-verify display name

### DIFF
--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -62,7 +62,7 @@ node {
     }
     sshagent(["openshift-bot"]) {
         stage("initialize") {
-            currentBuild.displayName = "#${currentBuild.number}"
+            currentBuild.displayName = "${params.BUILD_VERSION} - #${currentBuild.number}"
         }
 
         stage("conforma-verify") {


### PR DESCRIPTION
Shows the OCP version (e.g. `4.18 - #9`) in the Jenkins job title for easier identification in build history.

Made with [Cursor](https://cursor.com)