### PR TITLE
Add OCP Konflux kubeconfig to layered-products job

### DIFF
--- a/jobs/build/layered-products/Jenkinsfile
+++ b/jobs/build/layered-products/Jenkinsfile
@@ -151,6 +151,7 @@ node {
                             file(credentialsId: 'openshift-bot-logging-konflux-service-account', variable: 'LOGGING_KONFLUX_SA_KUBECONFIG'),
                             file(credentialsId: 'openshift-bot-acm-konflux-service-account', variable: 'ACM_KONFLUX_SA_KUBECONFIG'),
                             file(credentialsId: 'openshift-bot-oap-konflux-service-account', variable: 'OAP_KONFLUX_SA_KUBECONFIG'),
+                            file(credentialsId: 'openshift-bot-ocp-konflux-service-account', variable: 'KONFLUX_SA_KUBECONFIG'),
                             file(credentialsId: 'openshift-bot-assisted-installer-service-account', variable: 'ASSISTED_INSTALLER_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),


### PR DESCRIPTION
supplemental-tools builds use the ocp-art-tenant namespace and need the KONFLUX_SA_KUBECONFIG credential. The layered-products Jenkinsfile was missing this binding, causing builds to fail with: Kubeconfig required for Konflux builds.

Adds the openshift-bot-ocp-konflux-service-account credential as KONFLUX_SA_KUBECONFIG.

Ref: [ART-18773](https://redhat.atlassian.net/browse/ART-18773)

Made with [Cursor](https://cursor.com)