### PR TITLE
ART-19363: Add OCP_OPTIONAL params to release-from-fbc job

### DIFF
--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -29,7 +29,7 @@ node {
                     commonlib.artToolsParam(),
                     string(
                         name: 'GROUP',
-                        description: 'The group to use (e.g. oadp-1.3, logging-6.5, or openshift-4.22 with OCP_OPTIONAL)',
+                        description: 'The group to use (e.g. mta-8.1, logging-6.5, or openshift-4.22 with OCP_OPTIONAL)',
                         defaultValue: "oadp-1.3",
                         trim: true,
                     ),

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -105,6 +105,11 @@ node {
                           "Layered products (OADP, MTA, MTC, Logging) should use the default mode.")
                 }
 
+                if (!params.OCP_OPTIONAL && params.GROUP.startsWith('openshift-')) {
+                    error("GROUP '${params.GROUP}' is an openshift-* group and requires OCP_OPTIONAL to be enabled. " +
+                          "Without it, the default mode may filter out images and produce only FBC yaml.")
+                }
+
                 def cmd = [
                     "artcd",
                     "-v",

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -100,6 +100,11 @@ node {
                     error("At least one of FBC_PULLSPECS or EXTRA_IMAGE_NVRS must be provided")
                 }
 
+                if (params.OCP_OPTIONAL && !params.GROUP.startsWith('openshift-')) {
+                    error("OCP_OPTIONAL requires GROUP to start with 'openshift-' (e.g., openshift-4.22). " +
+                          "Layered products (OADP, MTA, MTC, Logging) should use the default mode.")
+                }
+
                 def cmd = [
                     "artcd",
                     "-v",

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -29,7 +29,7 @@ node {
                     commonlib.artToolsParam(),
                     string(
                         name: 'GROUP',
-                        description: 'The group to use with artcd release-from-fbc command',
+                        description: 'The group to use (e.g. oadp-1.3, logging-6.5, or openshift-4.22 with OCP_OPTIONAL)',
                         defaultValue: "oadp-1.3",
                         trim: true,
                     ),
@@ -60,6 +60,17 @@ node {
                     text(
                         name: 'EXTRA_IMAGE_NVRS',
                         description: 'Comma-separated list of extra image NVRs to include in the image shipment file (not part of the FBC). At least one of FBC_PULLSPECS or EXTRA_IMAGE_NVRS must be provided.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    booleanParam(
+                        name: 'OCP_OPTIONAL',
+                        description: 'Enable OCP optional-operator mode. Creates extras/fbc shipments with all FBC related images included. Use with GROUP=openshift-4.x.',
+                        defaultValue: false,
+                    ),
+                    string(
+                        name: 'EXCLUDE_NVR_COMPONENTS',
+                        description: '(Optional) Comma-separated NVR component names to explicitly exclude from shipment. Not needed in the default workflow.',
                         defaultValue: "",
                         trim: true,
                     ),
@@ -119,6 +130,16 @@ node {
                 if (targetDate) {
                     cmd << "--target-release-date"
                     cmd << "${targetDate}"
+                }
+
+                if (params.OCP_OPTIONAL) {
+                    cmd << "--ocp-optional"
+                }
+
+                def excludeNvrComponents = commonlib.cleanCommaList(params.EXCLUDE_NVR_COMPONENTS)
+                if (excludeNvrComponents) {
+                    cmd << "--exclude-nvr-components"
+                    cmd << "${excludeNvrComponents}"
                 }
 
                 if (params.DRY_RUN) {


### PR DESCRIPTION
Add OCP_OPTIONAL (boolean) and EXCLUDE_NVR_COMPONENTS (string) Jenkins parameters to support the new OCP optional-operator mode in artcd release-from-fbc. Passes --ocp-optional and --exclude-nvr-components flags to the artcd command when set.

This enables shipping OCP optional operators (e.g., metallb) that were excluded from the main release as a separate shipment MR.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

 - [ ] Depends-On: https://github.com/openshift-eng/art-tools/pull/2974