### PR TITLE
ART-14263: Add post-sync verification for S3 and Cloudflare R2 mirrors

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -660,6 +660,24 @@ def invalidateAwsCache(s3_path, dry_run=false) {
 
 }
 
+def verifySyncedToMirror(local_dir, s3_path) {
+    def s3_out = sh(
+        script: "aws s3 sync --no-progress --size-only --dryrun ${local_dir} s3://art-srv-enterprise${s3_path}",
+        returnStdout: true
+    ).trim()
+    if (s3_out) {
+        error("S3 post-sync verification failed -- files missing or size mismatch:\n${s3_out}")
+    }
+    def r2_out = sh(
+        script: "aws s3 sync --no-progress --size-only --dryrun ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
+        returnStdout: true
+    ).trim()
+    if (r2_out) {
+        error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
+    }
+    echo "Verified: all local files present in S3 and R2 for ${s3_path}"
+}
+
 def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, issue_cloudfront_invalidation=true, dry_run=false) {
     try {
         checkS3Path(s3_path)
@@ -686,6 +704,9 @@ def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, 
                         // 3. Everything should be sync'd in a consistent way -- delete anything old with --delete.
                         shell(script: "aws s3 sync ${opts} --delete ${local_dir} s3://art-srv-enterprise${s3_path}")
                         shell(script: "aws s3 sync ${opts} --delete ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}")
+                    }
+                    if (!dry_run) {
+                        verifySyncedToMirror(local_dir, s3_path)
                     }
                 }
             }
@@ -717,6 +738,7 @@ def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', time
                 timeout(time: timeout_minutes, unit: 'MINUTES') { // aws s3 sync has been observed to hang before
                     shell(script: "aws s3 sync --no-progress --exact-timestamps ${extra_args} ${local_dir} s3://art-srv-enterprise${s3_path}")
                     shell(script: "aws s3 sync --no-progress --exact-timestamps ${extra_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}")
+                    verifySyncedToMirror(local_dir, s3_path)
                 }
             }
             if (issue_cloudfront_invalidation) {

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -660,16 +660,21 @@ def invalidateAwsCache(s3_path, dry_run=false) {
 
 }
 
-def verifySyncedToMirror(local_dir, s3_path) {
+def verifySyncedToMirror(local_dir, s3_path, include_only='') {
+    def filter_args = ''
+    if (include_only) {
+        filter_args = "--exclude '*' --include '${include_only}'"
+    }
     def s3_out = sh(
-        script: "aws s3 sync --no-progress --size-only --dryrun ${local_dir} s3://art-srv-enterprise${s3_path}",
+        script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path}",
         returnStdout: true
     ).trim()
     if (s3_out) {
         error("S3 post-sync verification failed -- files missing or size mismatch:\n${s3_out}")
     }
+    sleep(15)
     def r2_out = sh(
-        script: "aws s3 sync --no-progress --size-only --dryrun ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
+        script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
         returnStdout: true
     ).trim()
     if (r2_out) {
@@ -738,7 +743,7 @@ def syncDirToS3Mirror(local_dir, s3_path, delete_old=true, include_only='', time
                 timeout(time: timeout_minutes, unit: 'MINUTES') { // aws s3 sync has been observed to hang before
                     shell(script: "aws s3 sync --no-progress --exact-timestamps ${extra_args} ${local_dir} s3://art-srv-enterprise${s3_path}")
                     shell(script: "aws s3 sync --no-progress --exact-timestamps ${extra_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}")
-                    verifySyncedToMirror(local_dir, s3_path)
+                    verifySyncedToMirror(local_dir, s3_path, include_only)
                 }
             }
             if (issue_cloudfront_invalidation) {


### PR DESCRIPTION
## Summary
- Adds a `verifySyncedToMirror` helper that runs a `--size-only --dryrun` sync from local to both S3 and R2 after every mirror sync
- Calls verification in both `syncRepoToS3Mirror` (after all 3 passes, skipped during dry_run) and `syncDirToS3Mirror` (after sync completes)
- Catches silent partial upload failures where `aws s3 sync` exits 0 but does not upload all files to R2, which can leave files permanently S3-only when `doozer beta:reposync --delete` later removes them locally
- Forwards the `include_only` filter to verification so it only checks the subset of files that were actually synced, avoiding false-positive failures
- Adds a 15-second sleep between S3 and R2 verification to account for R2 eventual consistency, avoiding unnecessary full re-syncs via `retry(3)`

Uses `--size-only` instead of `--exact-timestamps` to avoid false positives from timestamp precision differences between the local filesystem and Cloudflare R2.

## Test plan
- [x] Verify sync-for-ci job completes successfully with verification step
  - [Build #3](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/hack/job/ashwin-aos-cd-jobs/job/build%252Fsync-for-ci/3/console) (openshift-5.0, x86_64, DRY_RUN=false): Verification passed. Build failed due to unrelated CloudFront InvalidClientTokenId credential issue in the hack job.
- [x] Confirm verification does not produce false positives on a normal sync run
  - Same build above: no false positives observed; S3 and R2 dry-run checks returned empty output (all files matched).
- [ ] Validate that a simulated R2 mismatch triggers the retry mechanism

### Key log lines from Build #3

```
# S3 verification (dry-run sync to check for missing/mismatched files):
[2026-06-08T18:21:08.862Z] + aws s3 sync --no-progress --size-only --dryrun /mnt/jenkins-workspace/reposync/5.1/ s3://art-srv-enterprise/enterprise/reposync/5.1/

# 15-second sleep for R2 eventual consistency:
[2026-06-08T18:21:35.320Z] Sleeping for 15 sec

# R2 verification (dry-run sync to Cloudflare):
[2026-06-08T18:21:50.323Z] + aws s3 sync --no-progress --size-only --dryrun /mnt/jenkins-workspace/reposync/5.1/ s3://art-srv-enterprise/enterprise/reposync/5.1/ --profile cloudflare --endpoint-url ****

# Verification passed (no files reported as missing/mismatched):
[2026-06-08T18:23:12.484Z] Verified: all local files present in S3 and R2 for /enterprise/reposync/5.1/

# Unrelated failure — CloudFront invalidation credential issue in hack job:
[2026-06-08T18:23:16.932Z] An error occurred (InvalidClientTokenId) when calling the CreateInvalidation operation: The security token included in the request is invalid.
```

Made with [Cursor](https://cursor.com)