### PR TITLE
Add JIRA_TOKEN credential to sync-ci-images job

### DIFF
--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -147,6 +147,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                             usernamePassword(credentialsId: 'art_to_ci_promotion_robot--qci', usernameVariable: 'QCI_USER', passwordVariable: 'QCI_PASSWORD'),
                         ]) {
                         wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
## Summary
- Add `jboss-jira-token` credential binding (`JIRA_TOKEN`) to the sync-ci-images Jenkinsfile
- Required because `doozer images:streams prs open` calls `reconcile_jira_issues()` for OCP >= 4.16, which needs `JIRA_TOKEN` env var
- Without it, PR reconciliation fails with a `ValueError`

## Test plan
- [ ] Verify sync-ci-images job runs successfully for an OCP >= 4.16 version with PRs enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)