### PR TITLE
Add Jenkins jobs for gen-assembly-lp and prepare-release-lp (ART-19443)

### DIFF
--- a/jobs/build/gen-assembly-lp/Jenkinsfile
+++ b/jobs/build/gen-assembly-lp/Jenkinsfile
@@ -1,0 +1,163 @@
+#!/usr/bin/env groovy
+
+node {
+    timestamps {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    commonlib.describeJob("gen-assembly-lp", """
+        <h2>Generate an assembly definition for Layered Products from FBC images</h2>
+        Extracts operand NVRs from FBC images and creates an assembly definition
+        in <code>releases.yml</code>. Supports assembly inheritance via
+        <code>BASIS_ASSEMBLY</code> for lightweight z-stream releases.
+        <br><br>
+        A pull request will be created to add the generated assembly definition
+        to ocp-build-data. It is the ARTist's responsibility to review and merge the PR.
+    """)
+
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '30',
+                    daysToKeepStr: '30')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.dryrunParam(),
+                    commonlib.mockParam(),
+                    commonlib.artToolsParam(),
+                    string(
+                        name: 'GROUP',
+                        description: 'The group to use (e.g. acm-2.17, mce-2.17, oadp-1.5)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'ASSEMBLY',
+                        description: 'The assembly name to generate (e.g. 2.17.3)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    text(
+                        name: 'FBC_PULLSPECS',
+                        description: 'Comma-separated FBC image pullspecs to extract operand NVRs from. Required unless BASIS_ASSEMBLY is provided.',
+                        defaultValue: "",
+                    ),
+                    string(
+                        name: 'BASIS_ASSEMBLY',
+                        description: '(Optional) Inherit from an existing assembly. The new assembly will inherit all operand pins from the parent. Use INCLUDE to swap specific builds.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    text(
+                        name: 'INCLUDE',
+                        description: '(Optional) Comma-separated list of operand swaps. Format: distgit_key=nvr (e.g. search-v2-api-container=search-v2-api-container-2.17.4-1)',
+                        defaultValue: "",
+                    ),
+                    text(
+                        name: 'EXTRA_IMAGE_NVRS',
+                        description: '(Optional) Comma-separated extra operand NVRs not in FBC catalog.',
+                        defaultValue: "",
+                    ),
+                    string(
+                        name: 'DOOZER_DATA_PATH',
+                        description: 'ocp-build-data URL (default: openshift-eng/ocp-build-data)',
+                        defaultValue: "https://github.com/openshift-eng/ocp-build-data",
+                        trim: true,
+                    ),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    if (currentBuild.description == null) {
+        currentBuild.description = ""
+    }
+    sshagent(["openshift-bot"]) {
+        stage("initialize") {
+            currentBuild.displayName = "#${currentBuild.number} ${params.GROUP} ${params.ASSEMBLY}"
+        }
+
+        try {
+            stage("gen-assembly-lp") {
+                def cmd = [
+                    "artcd",
+                    "-v",
+                    "--working-dir=./artcd_working",
+                    "--config=./config/artcd.toml",
+                    "gen-assembly-lp",
+                    "--group", "${params.GROUP}",
+                    "--assembly", "${params.ASSEMBLY}",
+                    "--data-path", "${params.DOOZER_DATA_PATH}",
+                ]
+
+                def fbcPullspecs = commonlib.cleanCommaList(params.FBC_PULLSPECS)
+                if (fbcPullspecs) {
+                    cmd += ["--fbc-pullspecs", fbcPullspecs]
+                }
+
+                def basisAssembly = params.BASIS_ASSEMBLY?.trim()
+                if (basisAssembly) {
+                    cmd += ["--basis-assembly", basisAssembly]
+                }
+
+                if (!fbcPullspecs && !basisAssembly) {
+                    error("At least one of FBC_PULLSPECS or BASIS_ASSEMBLY must be provided")
+                }
+
+                def includes = commonlib.cleanCommaList(params.INCLUDE)
+                if (includes) {
+                    includes.split(',').each { inc ->
+                        cmd += ["--include", inc.trim()]
+                    }
+                }
+
+                def extraNvrs = commonlib.cleanCommaList(params.EXTRA_IMAGE_NVRS)
+                if (extraNvrs) {
+                    cmd += ["--extra-image-nvrs", extraNvrs]
+                }
+
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+
+                wrap([$class: 'BuildUser']) {
+                    builderEmail = env.BUILD_USER_EMAIL
+                }
+
+                buildlib.withAppCiAsArtPublish() {
+                    withCredentials([
+                        string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                        string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                        string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                        string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                        file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                        string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
+                        file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
+                    ]){
+                        def envVars = ["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]
+                        withEnv(envVars) {
+                            buildlib.init_artcd_working_dir()
+                            sh(script: cmd.join(' '), returnStdout: true)
+                        }
+                    }
+                }
+            }
+        } finally {
+            stage("terminate") {
+                commonlib.safeArchiveArtifacts([
+                    "artcd_working/**/*.log",
+                    "artcd_working/**/*.yaml",
+                    "artcd_working/**/*.yml",
+                ])
+                buildlib.cleanWorkspace()
+            }
+        }
+    }
+    }
+}

--- a/jobs/build/prepare-release-lp/Jenkinsfile
+++ b/jobs/build/prepare-release-lp/Jenkinsfile
@@ -1,0 +1,159 @@
+#!/usr/bin/env groovy
+
+node {
+    timestamps {
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    commonlib.describeJob("prepare-release-lp", """
+        <h2>Prepare a Layered Product release from a named assembly</h2>
+        Reads the assembly definition from <code>releases.yml</code>, triggers
+        OLM bundle and FBC builds using the pinned operand NVRs, then creates
+        a shipment MR in the GitLab shipment data repository.
+        <br><br>
+        The assembly must already exist in ocp-build-data (created by gen-assembly-lp).
+    """)
+
+    properties(
+        [
+            disableResume(),
+            buildDiscarder(
+                logRotator(
+                    artifactDaysToKeepStr: '30',
+                    daysToKeepStr: '30')),
+            [
+                $class: 'ParametersDefinitionProperty',
+                parameterDefinitions: [
+                    commonlib.dryrunParam(),
+                    commonlib.mockParam(),
+                    commonlib.artToolsParam(),
+                    string(
+                        name: 'GROUP',
+                        description: 'The group to use (e.g. acm-2.17, mce-2.17)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'ASSEMBLY',
+                        description: 'The named assembly to prepare (e.g. 2.17.3). Must exist in releases.yml.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    text(
+                        name: 'JIRA_BUGS',
+                        description: '(Optional) Comma-separated JIRA issue IDs for release notes (e.g. ACM-1234,ACM-5678)',
+                        defaultValue: "",
+                    ),
+                    string(
+                        name: 'TARGET_RELEASE_DATE',
+                        description: '(Optional) Target ship date (e.g. 2026-Mar-31 or 2026-03-31). Included in MR title.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'BUILD_DATA_REPO_URL',
+                        description: 'ocp-build-data pull URL (default: openshift-eng/ocp-build-data)',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                    string(
+                        name: 'SHIPMENT_DATA_REPO_URL',
+                        description: '(Optional) GitLab shipment data repo URL override.',
+                        defaultValue: "",
+                        trim: true,
+                    ),
+                ]
+            ],
+        ]
+    )
+
+    commonlib.checkMock()
+
+    if (currentBuild.description == null) {
+        currentBuild.description = ""
+    }
+    sshagent(["openshift-bot"]) {
+        stage("initialize") {
+            currentBuild.displayName = "#${currentBuild.number} ${params.GROUP} ${params.ASSEMBLY}"
+        }
+
+        try {
+            stage("prepare-release-lp") {
+                def cmd = [
+                    "artcd",
+                    "-v",
+                    "--working-dir=./artcd_working",
+                    "--config=./config/artcd.toml",
+                    "prepare-release-lp",
+                    "--group", "${params.GROUP}",
+                    "--assembly", "${params.ASSEMBLY}",
+                    "--create-mr"
+                ]
+
+                def buildDataUrl = params.BUILD_DATA_REPO_URL?.trim()
+                if (buildDataUrl) {
+                    cmd += ["--build-data-repo-url", buildDataUrl]
+                }
+
+                def shipmentDataUrl = params.SHIPMENT_DATA_REPO_URL?.trim()
+                if (shipmentDataUrl) {
+                    cmd += ["--shipment-data-repo-url", shipmentDataUrl]
+                }
+
+                def jiraBugs = commonlib.cleanCommaList(params.JIRA_BUGS)
+                if (jiraBugs) {
+                    cmd += ["--jira-bugs", jiraBugs]
+                }
+
+                def targetDate = params.TARGET_RELEASE_DATE?.trim()
+                if (targetDate) {
+                    cmd += ["--target-release-date", targetDate]
+                }
+
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+
+                wrap([$class: 'BuildUser']) {
+                    builderEmail = env.BUILD_USER_EMAIL
+                }
+
+                buildlib.withAppCiAsArtPublish() {
+                    withCredentials([
+                        string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                        string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                        string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
+                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
+                        file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                        file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                        string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
+                        string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
+                        file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
+                    ]){
+                        def envVars = ["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']
+                        withEnv(envVars) {
+                            buildlib.init_artcd_working_dir()
+                            try {
+                                sh(script: cmd.join(' '), returnStdout: true)
+                            } catch (err) {
+                                currentBuild.result = "UNSTABLE"
+                            }
+                        }
+                    }
+                }
+            }
+        } finally {
+            stage("terminate") {
+                commonlib.safeArchiveArtifacts([
+                    "artcd_working/**/*.log",
+                    "artcd_working/**/*.yaml",
+                    "artcd_working/**/*.yml",
+                ])
+                buildlib.cleanWorkspace()
+            }
+        }
+    }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `gen-assembly-lp` Jenkins job: generates LP assembly definitions from FBC images with support for operand swaps (`--include`) and assembly inheritance (`--basis-assembly`)
- Adds `prepare-release-lp` Jenkins job: prepares LP releases from named assemblies, building bundles/FBCs and creating shipment MRs

## Context

Companion to [art-tools#2989](https://github.com/openshift-eng/art-tools/pull/2989) which adds the `artcd gen-assembly-lp` and `artcd prepare-release-lp` CLI commands. These Jenkins jobs provide the CI interface for running those pipelines.

## Test plan

- [ ] Verify Jenkins job parameters render correctly
- [ ] Dry-run gen-assembly-lp with a real ACM group/FBC
- [ ] Dry-run prepare-release-lp with a real ACM assembly


Made with [Cursor](https://cursor.com)