### PR TITLE
build-sync: Add QCI credentials for RHCOS mirroring

### DIFF
--- a/jobs/build/build-sync-konflux/Jenkinsfile
+++ b/jobs/build/build-sync-konflux/Jenkinsfile
@@ -221,6 +221,7 @@ node() {
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                    usernamePassword(credentialsId: 'art_to_ci_promotion_robot--qci', usernameVariable: 'QCI_USER', passwordVariable: 'QCI_PASSWORD'),
                 ]) {
                     def envVars = ["BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]
                     if (params.TELEMETRY_ENABLED) {


### PR DESCRIPTION
## Summary
- Add QCI_USER and QCI_PASSWORD credentials to build-sync Jenkinsfiles
- Required for RHCOS image mirroring to quay.io/openshift/ci

## Changes
- Add `art_to_ci_promotion_robot--qci` credential binding to:
  - `jobs/build/build-sync/Jenkinsfile`
  - `jobs/build/build-sync-konflux/Jenkinsfile`

## Test plan
- [ ] Deploy and verify build-sync can mirror RHCOS images to QCI

## Related
- Depends on: https://github.com/openshift-eng/art-tools/pull/2991