### PR TITLE
Add USE_NEW_GOLANG_BRANCH param to golang-builder job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -79,6 +79,11 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
+                        name: 'USE_NEW_GOLANG_BRANCH',
+                        description: 'Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
                         name: 'MAJOR_BUMP',
                         description: 'Indicates a major.minor golang version bump (e.g. 1.22 -> 1.23). Permits validation of go_latest even when the new version does not match current group.yml vars.',
                         defaultValue: false,
@@ -181,6 +186,9 @@ node {
                         }
                         if (params.EXTERNAL_GOLANG_RPMS) {
                             cmd << "--external-golang-rpms"
+                        }
+                        if (params.USE_NEW_GOLANG_BRANCH) {
+                            cmd << "--use-new-golang-branch"
                         }
                         if (params.MAJOR_BUMP) {
                             cmd << "--major-bump"


### PR DESCRIPTION
## Summary
- Adds `USE_NEW_GOLANG_BRANCH` boolean parameter to the golang-builder Jenkins job
- Passes `--use-new-golang-branch` flag to `artcd update-golang` when set
- Corresponds to the flag added in [art-tools#3003](https://github.com/openshift-eng/art-tools/pull/3003)

## Test plan
- [ ] Trigger golang-builder job with `USE_NEW_GOLANG_BRANCH` checked and verify the flag is passed to artcd

🤖 Generated with [Claude Code](https://claude.com/claude-code)