### PR TITLE
Fix --dry-run flag placement in LP Jenkinsfiles

### DIFF
--- a/jobs/build/gen-assembly-lp/Jenkinsfile
+++ b/jobs/build/gen-assembly-lp/Jenkinsfile
@@ -96,6 +96,11 @@ node {
                     "-v",
                     "--working-dir=./artcd_working",
                     "--config=./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
                     "gen-assembly-lp",
                     "--group", "${params.GROUP}",
                     "--assembly", "${params.ASSEMBLY}",
@@ -126,10 +131,6 @@ node {
                 def extraNvrs = commonlib.cleanCommaList(params.EXTRA_IMAGE_NVRS)
                 if (extraNvrs) {
                     cmd += ["--extra-image-nvrs", extraNvrs]
-                }
-
-                if (params.DRY_RUN) {
-                    cmd << "--dry-run"
                 }
 
                 wrap([$class: 'BuildUser']) {

--- a/jobs/build/prepare-release-lp/Jenkinsfile
+++ b/jobs/build/prepare-release-lp/Jenkinsfile
@@ -85,6 +85,11 @@ node {
                     "-v",
                     "--working-dir=./artcd_working",
                     "--config=./config/artcd.toml",
+                ]
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+                cmd += [
                     "prepare-release-lp",
                     "--group", "${params.GROUP}",
                     "--assembly", "${params.ASSEMBLY}",
@@ -109,10 +114,6 @@ node {
                 def targetDate = params.TARGET_RELEASE_DATE?.trim()
                 if (targetDate) {
                     cmd += ["--target-release-date", targetDate]
-                }
-
-                if (params.DRY_RUN) {
-                    cmd << "--dry-run"
                 }
 
                 wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
## Summary
- Move `--dry-run` flag before the subcommand name in both `gen-assembly-lp` and `prepare-release-lp` Jenkinsfiles
- `--dry-run` is a flag on the `artcd` parent command, not on the subcommands, so placing it after the subcommand causes `Error: No such option: --dry-run`

## Test plan
- [x] Reproduced: triggered gen-assembly-lp with DRY_RUN=true, got `No such option: --dry-run`
- [ ] After merge, re-trigger gen-assembly-lp with DRY_RUN=true and confirm it works


Made with [Cursor](https://cursor.com)