### PR TITLE
prepare-release-lp: add LP-specific Konflux kubeconfig credentials

### DIFF
--- a/jobs/build/prepare-release-lp/Jenkinsfile
+++ b/jobs/build/prepare-release-lp/Jenkinsfile
@@ -129,9 +129,16 @@ node {
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                         file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                         file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                        file(credentialsId: 'creds_registry.redhat.io', variable: 'KONFLUX_OPERATOR_INDEX_AUTH_FILE'),
                         string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
                         string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                         file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
+                        file(credentialsId: 'openshift-bot-logging-konflux-service-account', variable: 'LOGGING_KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'openshift-bot-oadp-konflux-service-account', variable: 'OADP_KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'openshift-bot-mta-konflux-service-account', variable: 'MTA_KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'openshift-bot-mtc-konflux-service-account', variable: 'MTC_KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'openshift-bot-acm-konflux-service-account', variable: 'ACM_KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'openshift-bot-oap-konflux-service-account', variable: 'OAP_KONFLUX_SA_KUBECONFIG'),
                     ]){
                         def envVars = ["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}", 'DOOZER_DB_NAME=art_dash']
                         withEnv(envVars) {


### PR DESCRIPTION
## Summary
- Add product-specific Konflux service account kubeconfigs (logging, oadp, mta, mtc, acm, oap) to the `prepare-release-lp` Jenkinsfile
- Add `KONFLUX_OPERATOR_INDEX_AUTH_FILE` credential for registry auth
- Without these, doozer falls back to `art-publish` which lacks RBAC permissions in LP Konflux namespaces

Companion art-tools PR: https://github.com/openshift-eng/art-tools/pull/2989

## Test plan
- [x] Verified credential names match those used in `build-fbc` and `olm_bundle_konflux` Jenkinsfiles
- [ ] Trigger `prepare-release-lp` for `logging-6.4` assembly `6.4.5` and confirm no 403 Forbidden errors


Made with [Cursor](https://cursor.com)