### PR TITLE
Rename gen-assembly-lp and prepare-release-lp to layered-products-*

### DIFF
--- a/jobs/build/layered-products-gen-assembly/Jenkinsfile
+++ b/jobs/build/layered-products-gen-assembly/Jenkinsfile
@@ -6,7 +6,7 @@ node {
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
 
-    commonlib.describeJob("gen-assembly-lp", """
+    commonlib.describeJob("layered-products-gen-assembly", """
         <h2>Generate an assembly definition for Layered Products from FBC images</h2>
         Extracts operand NVRs from FBC images and creates an assembly definition
         in <code>releases.yml</code>. Supports assembly inheritance via
@@ -90,7 +90,7 @@ node {
         }
 
         try {
-            stage("gen-assembly-lp") {
+            stage("layered-products-gen-assembly") {
                 def cmd = [
                     "artcd",
                     "-v",

--- a/jobs/build/layered-products-prepare-release/Jenkinsfile
+++ b/jobs/build/layered-products-prepare-release/Jenkinsfile
@@ -6,13 +6,13 @@ node {
     def buildlib = load("pipeline-scripts/buildlib.groovy")
     def commonlib = buildlib.commonlib
 
-    commonlib.describeJob("prepare-release-lp", """
+    commonlib.describeJob("layered-products-prepare-release", """
         <h2>Prepare a Layered Product release from a named assembly</h2>
         Reads the assembly definition from <code>releases.yml</code>, triggers
         OLM bundle and FBC builds using the pinned operand NVRs, then creates
         a shipment MR in the GitLab shipment data repository.
         <br><br>
-        The assembly must already exist in ocp-build-data (created by gen-assembly-lp).
+        The assembly must already exist in ocp-build-data (created by layered-products-gen-assembly).
     """)
 
     properties(
@@ -79,7 +79,7 @@ node {
         }
 
         try {
-            stage("prepare-release-lp") {
+            stage("layered-products-prepare-release") {
                 def cmd = [
                     "artcd",
                     "-v",


### PR DESCRIPTION
## Summary
- Rename `gen-assembly-lp` → `layered-products-gen-assembly`
- Rename `prepare-release-lp` → `layered-products-prepare-release`
- Update `describeJob()`, `stage()`, and cross-references in Jenkinsfiles
- artcd CLI subcommand names (`gen-assembly-lp`, `prepare-release-lp`) are unchanged

## Test plan
- [ ] Verify Jenkins picks up the renamed job directories
- [ ] Trigger a dry-run of both jobs to confirm they execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)