### PR TITLE
Add acm-2.16 to nonOCPGroups for layered-products scan

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -35,6 +35,7 @@ okdVersions = [
 ]
 
 nonOCPGroups = [
+    "acm-2.16",
     "logging-6.0",
     "logging-6.2",
     "logging-6.3",


### PR DESCRIPTION
## Summary
- Adds `acm-2.16` to the `nonOCPGroups` list in `pipeline-scripts/commonlib.groovy`
- This enables the scheduled layered-products scan job to include the `acm-2.16` group

## Test plan
- [ ] Verify the `layered-operators-scan` job picks up `acm-2.16` on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)