### PR TITLE
Fix missing certifi cacert.pem: change UV_LINK_MODE from symlink to copy

### DIFF
--- a/pipeline-scripts/buildlib.groovy
+++ b/pipeline-scripts/buildlib.groovy
@@ -175,7 +175,7 @@ def setup_venv() {
     // Preparing venv for ART tools
     // The following commands will run automatically every time one of our jobs
     // loads buildlib (ideally, once per pipeline)
-    withEnv(['UV_LINK_MODE=symlink', 'PATH+MYCARGO=~/.cargo/bin']) {
+    withEnv(['UV_LINK_MODE=copy', 'PATH+MYCARGO=~/.cargo/bin']) {
         VIRTUAL_ENV = "${env.WORKSPACE}/art-venv"
         commonlib.shell(script: """
             rm -rf ${VIRTUAL_ENV}


### PR DESCRIPTION
UV_LINK_MODE=symlink creates symlinks from the venv to uv's shared storage. When the symlink target for certifi/cacert.pem becomes unavailable, requests raises OSError before SSL connections are attempted, causing BigQuery writes to fail and cascading build failures.

pip-system-certs is already a dependency in art-tools pyproject.toml and cannot help because requests checks os.path.exists(certifi.where()) before truststore gets a chance to handle the connection.

Changing to UV_LINK_MODE=copy ensures all files (including data files like cacert.pem) are physically copied into the venv.