### PR TITLE
Handle sync-ci-images partial success as UNSTABLE

### DIFF
--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -159,7 +159,13 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                                 echo "Will run ${cmd.join(' ')}"
 
                                 timeout(activity: true, time: 120, unit: 'MINUTES') {
-                                    sh(script: cmd.join(' '))
+                                    def rc = sh(script: cmd.join(' '), returnStatus: true)
+                                    if (rc == 25) {
+                                        currentBuild.result = 'UNSTABLE'
+                                        echo "sync-ci-images completed with partial errors (rc=25)"
+                                    } else if (rc != 0) {
+                                        error("sync-ci-images failed with exit code ${rc}")
+                                    }
                                 }
 
                             } catch (err) {


### PR DESCRIPTION
When artcd sync-ci-images exits with code 25 (partial success), mark the Jenkins build as UNSTABLE (yellow) instead of FAILURE (red). This allows the pipeline to report that some steps succeeded while others had issues (e.g. missing Konflux builds, missing CI images).