### PR TITLE
update the list of EOL OCP versions to save diskspace,

### DIFF
--- a/scheduled-jobs/build/sync-for-ci/Jenkinsfile
+++ b/scheduled-jobs/build/sync-for-ci/Jenkinsfile
@@ -38,7 +38,8 @@ def runFor(group, dir, arch="x86_64") {
 @NonCPS
 def sortedVersions() {
   // Return versions honoring semver, but exclude disabled
-  def disabled = []
+  // update the disabled list according to https://access.redhat.com/support/policy/updates/openshift
+  def disabled = ["4.12", "4.13", "4.15", "4.17"]
   def s = commonlib.ocpMajorVersions["4plus"].sort(false) {
     def major_minor = it.tokenize('.')
 


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
addressed [ART-19727](https://redhat.atlassian.net/browse/ART-19727)