### PR TITLE
Fix duplicate version tag in sync-ci-images job title

### DIFF
--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -87,7 +87,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
         }
 
         stage("Initialize") {
-            currentBuild.displayName = "#${currentBuild.number} [${params.VERSION}]"
+            currentBuild.displayName = "#${currentBuild.number}"
 
             if (params.DRY_RUN) {
                 currentBuild.displayName += " [DRY_RUN]"


### PR DESCRIPTION
## Problem
The sync-ci-images Jenkins job was displaying duplicate version tags in the build title (e.g., `[4.18] [4.18] #123`).

## Root Cause
Both the Jenkinsfile and pyartcd were adding the version tag:
- **Jenkinsfile** (line 90): `currentBuild.displayName = "#${currentBuild.number} [${params.VERSION}]"`
- **pyartcd** (sync_ci_images.py:628): `jenkins.update_title(f' [{self.version}]')`

This resulted in the version tag being added twice.