### PR TITLE
Add mce-2.11 to nonOCPGroups for layered-products scan

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -36,6 +36,7 @@ okdVersions = [
 
 nonOCPGroups = [
     "acm-2.16",
+    "mce-2.11",
     "logging-6.0",
     "logging-6.2",
     "logging-6.3",


### PR DESCRIPTION
## Summary
- Add `mce-2.11` to `nonOCPGroups` so the scheduled layered-products scan includes MCE 2.11 (same pattern as acm-2.16 in b7cced131).

## Test plan
- [ ] Verify next `scheduled-jobs/build/layered-operators-scan` run passes `--group=mce-2.11` to artcd
- [ ] Optional: trigger `build/layered-products-scan` with `GROUP=mce-2.11`, `DRY_RUN=true`

Made with [Cursor](https://cursor.com)