### PR TITLE
Add EC_POLICY parameter to build-conforma-verify Jenkins job

### DIFF
--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -50,6 +50,12 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
+                    string(
+                        name: 'EC_POLICY',
+                        description: '(Optional) EnterpriseContractPolicy CR to use (namespace/name). Defaults to ocp-art-tenant/conforma-build-stage. Example: ocp-art-tenant/conforma-build-stage-test',
+                        defaultValue: "",
+                        trim: true,
+                    ),
                 ]
             ],
         ]
@@ -88,6 +94,9 @@ node {
             }
             if (params.BUILD_LIST) {
                 cmd << "--builds=${commonlib.cleanCommaList(params.BUILD_LIST)}"
+            }
+            if (params.EC_POLICY) {
+                cmd << "--ec-policy=${params.EC_POLICY}"
             }
 
             buildlib.withAppCiAsArtPublish() {


### PR DESCRIPTION
## Summary
- Add optional `EC_POLICY` Jenkins parameter to the `build-conforma-verify` job
- When set, passes `--ec-policy=<value>` to `artcd build-conforma-verify`, allowing operators to override the default `EnterpriseContractPolicy` CR (`ocp-art-tenant/conforma-build-stage`)
- Example use: `ocp-art-tenant/conforma-build-stage-test` for testing with a different policy

## Related PRs
- art-tools: https://github.com/openshift-eng/art-tools/pull/2951 (adds the `--ec-policy` CLI option)
- konflux-release-data: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/18969 (adds the `conforma-build-stage-test` policy CR)

## Test plan
- [ ] Trigger `build-conforma-verify` with `EC_POLICY` left empty -- should use default policy
- [ ] Trigger with `EC_POLICY=ocp-art-tenant/conforma-build-stage-test` -- should use custom policy

Made with [Cursor](https://cursor.com)