### PR TITLE
fix(release-from-fbc): place --dry-run before subcommand

### DIFF
--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -115,6 +115,13 @@ node {
                     "-v",
                     "--working-dir=./artcd_working",
                     "--config=./config/artcd.toml",
+                ]
+
+                if (params.DRY_RUN) {
+                    cmd << "--dry-run"
+                }
+
+                cmd += [
                     "release-from-fbc",
                     "--group",
                     "${params.GROUP}",
@@ -150,10 +157,6 @@ node {
                 if (excludeNvrComponents) {
                     cmd << "--exclude-nvr-components"
                     cmd << "${excludeNvrComponents}"
-                }
-
-                if (params.DRY_RUN) {
-                    cmd << "--dry-run"
                 }
 
                 // Needed to detect manual builds


### PR DESCRIPTION
## Summary
- `--dry-run` is a global option on the `artcd` CLI group (defined in `pyartcd/cli.py`), not on the `release-from-fbc` subcommand
- Click requires parent group options to appear **before** the subcommand name
- The Jenkinsfile was appending `--dry-run` after `release-from-fbc`, causing `Error: No such option: --dry-run`
- Moves the `--dry-run` flag insertion to before the `release-from-fbc` subcommand in the command list

## Test plan
- [x] Verified `--dry-run` is defined as a global option in `pyartcd/cli.py:60`
- [x] Audited all `dry_run` usage in `release_from_fbc.py` — all mutating operations (git push, MR creation, approval rules, CI triggers) are properly guarded
- [ ] Trigger a DRY_RUN=true build of release-from-fbc to verify the fix

Fixes failure in [build #104](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frelease-from-fbc/104/)