### PR TITLE
fix(layered-products): place --dry-run before subcommand

### DIFF
--- a/jobs/build/layered-products/Jenkinsfile
+++ b/jobs/build/layered-products/Jenkinsfile
@@ -119,6 +119,13 @@ node {
                 "-v",
                 "--working-dir=./artcd_working",
                 "--config=./config/artcd.toml",
+            ]
+
+            if (params.DRY_RUN) {
+                cmd << "--dry-run"
+            }
+
+            cmd += [
                 "build-layered-products",
                 "-g",
                 "${params.GROUP}",
@@ -133,9 +140,6 @@ node {
             }
             if (params.SKIP_REBASE) {
                 cmd << "--skip-rebase"
-            }
-            if (params.DRY_RUN) {
-                cmd << "--dry-run"
             }
             if (params.NETWORK_MODE && params.NETWORK_MODE != "") {
                 cmd << "--network-mode=${params.NETWORK_MODE}"


### PR DESCRIPTION
## Summary
- Same class of bug as [#4731](https://github.com/openshift-eng/aos-cd-jobs/pull/4731) (release-from-fbc)
- `--dry-run` is a global option on the `artcd` CLI group, not on the `build-layered-products` subcommand
- Click requires parent group options to appear **before** the subcommand name
- The Jenkinsfile was appending `--dry-run` after `build-layered-products`, which would cause `Error: No such option: --dry-run`
- Moves the `--dry-run` flag insertion to before the subcommand, matching the pattern used by all other working jobs (build-fbc, ocp4-konflux, gen-assembly, etc.)

## Test plan
- [x] Verified `--dry-run` is defined only as a global option in `pyartcd/cli.py:60`, not on `build-layered-products` subcommand
- [x] Audited all other Jenkinsfiles — this was the only remaining job with the bug
- [ ] Trigger a DRY_RUN=true build of layered-products to verify the fix