### PR TITLE
Add INCLUDE_BUNDLES and INCLUDE_FBCS params to build-conforma-verify

### DIFF
--- a/jobs/build/build-conforma-verify/Jenkinsfile
+++ b/jobs/build/build-conforma-verify/Jenkinsfile
@@ -56,6 +56,16 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
+                    booleanParam(
+                        name: 'INCLUDE_BUNDLES',
+                        description: 'Also verify latest OLM bundle builds',
+                        defaultValue: false,
+                    ),
+                    booleanParam(
+                        name: 'INCLUDE_FBCS',
+                        description: 'Also verify latest FBC (File-Based Catalog) builds',
+                        defaultValue: false,
+                    ),
                 ]
             ],
         ]
@@ -97,6 +107,12 @@ node {
             }
             if (params.EC_POLICY) {
                 cmd << "--ec-policy=${params.EC_POLICY}"
+            }
+            if (params.INCLUDE_BUNDLES) {
+                cmd << "--include-bundles"
+            }
+            if (params.INCLUDE_FBCS) {
+                cmd << "--include-fbcs"
             }
 
             buildlib.withAppCiAsArtPublish() {


### PR DESCRIPTION
## Summary

- Add `INCLUDE_BUNDLES` and `INCLUDE_FBCS` boolean Jenkins parameters to the build-conforma-verify job
- When checked, passes `--include-bundles` / `--include-fbcs` flags to `artcd build-conforma-verify`
- Depends on art-tools PR: https://github.com/openshift-eng/art-tools/pull/3059

## Test plan

- [ ] Verify Jenkins job parameters render correctly
- [ ] Run with INCLUDE_BUNDLES=true and DRY_RUN=true to confirm the flag is passed through
- [ ] Run with INCLUDE_FBCS=true and DRY_RUN=true to confirm the flag is passed through


Made with [Cursor](https://cursor.com)