### PR TITLE
Fix rhcos_sync crash for OCP 5.x releases

### DIFF
--- a/rhcoslib.groovy
+++ b/rhcoslib.groovy
@@ -25,8 +25,10 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     buildParts = rhcosBuild.split("\\.")
     ocpStream = ocpVersion
     minor = ocpVersion.split("\\.")
-    if ( minor[1].toInteger() > 18 ) {
-        // For 4.19 the rhcosBuild name is in format 9.6.20250121-0
+    majorNum = minor[0].asType(Integer)
+    minorNum = minor[1].asType(Integer)
+    if ( majorNum > 4 || (majorNum == 4 && minorNum > 18) ) {
+        // For 4.19+ / 5.x+ the rhcosBuild name is in format 9.6.20250121-0
         rhelStream = buildParts[0] + '.' + buildParts[1]
         stream = "rhel-${rhelStream}"
     } else {


### PR DESCRIPTION
## Summary
- The version check in `rhcoslib.initialize()` only compared the minor version (`> 18`) to choose between new-format and legacy RHCOS build IDs. For OCP 5.0, minor is `0`, so it incorrectly took the legacy 4.18-and-below path where the new-format build ID (`9.8.20260403-0`) triggers a `StringIndexOutOfBoundsException`.
- Added a major version check (`>= 5`) so all 5.x+ releases use the new RHCOS build format path.

## Test plan
- [x] Verified the root cause from [build #2482 console log](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Frhcos_sync/2482/console)
- [ ] Re-run `rhcos_sync` with `RELEASE_TAG=5.0.0-ec.2-s390x` after merge to confirm fix

Made with [Cursor](https://cursor.com)