### PR TITLE
Fix rhcos_sync: use toInteger() instead of asType(Integer)

### DIFF
--- a/jobs/build/rhcos_sync/rhcoslib.groovy
+++ b/jobs/build/rhcos_sync/rhcoslib.groovy
@@ -25,8 +25,8 @@ def initialize(ocpVersion, rhcosBuild, arch, name, mirrorPrefix) {
     buildParts = rhcosBuild.split("\\.")
     ocpStream = ocpVersion
     minor = ocpVersion.split("\\.")
-    majorNum = minor[0].asType(Integer)
-    minorNum = minor[1].asType(Integer)
+    majorNum = minor[0].toInteger()
+    minorNum = minor[1].toInteger()
     if ( majorNum > 4 || (majorNum == 4 && minorNum > 18) ) {
         // For 4.19+ / 5.x+ the rhcosBuild name is in format 9.6.20250121-0
         rhelStream = buildParts[0] + '.' + buildParts[1]


### PR DESCRIPTION
## Summary
- Follow-up to #4736. `asType(Integer)` is not whitelisted in the Jenkins script security sandbox, causing a `RejectedAccessException` at runtime.
- Replaced with `toInteger()` which is already approved and was used in the original code.

## Test plan
- [ ] Re-run `rhcos_sync` with `RELEASE_TAG=5.0.0-ec.2-s390x` after merge to confirm fix

Made with [Cursor](https://cursor.com)