### PR TITLE
feat(sync-ci-images): add IMAGES parameter for targeting individual CI-synced images

### DIFF
--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -44,7 +44,13 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                         ),
                         string(
                             name: 'ONLY_STREAM',
-                            description: '(Optional) Only sync images for the specified stream name',
+                            description: '(Optional) Only sync images for the specified stream name from streams.yml',
+                            defaultValue: "",
+                            trim: true,
+                        ),
+                        string(
+                            name: 'IMAGES',
+                            description: '(Optional) Comma-separated distgit keys to sync (e.g. ci-openshift-base.rhel10). Must have ci_alignment.upstream_image set.',
                             defaultValue: "",
                             trim: true,
                         ),
@@ -121,6 +127,9 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                 }
                 if (params.ONLY_STREAM) {
                     cmd << "--only-stream=${params.ONLY_STREAM}"
+                }
+                if (params.IMAGES) {
+                    cmd << "--images=${params.IMAGES}"
                 }
                 if (params.SKIP_PRS) {
                     cmd << "--skip-prs"


### PR DESCRIPTION
## Summary
- Adds an `IMAGES` Jenkins parameter (comma-separated distgit keys) to the sync-ci-images job
- Passes `--images=` to the `artcd sync-ci-images` CLI, which maps to `--image` on each doozer subcommand
- Companion PR: https://github.com/openshift-eng/art-tools/pull/$(cd /home/jdelft/src/github.com/openshift-eng/art-tools && gh pr list --head fix-sync-ci-images-only-stream --json number -q '.[0].number' 2>/dev/null || echo 'TBD')

## Test plan
- [ ] Run sync-ci-images with `IMAGES=ci-openshift-base.rhel10` and verify only that image is processed
- [ ] Run sync-ci-images without IMAGES and verify full sync still works