### PR TITLE
ART-21084: ci(jenkins): align okdVersions with build-data enabled matrix

### DIFF
--- a/jobs/build/okd-scan/README.md
+++ b/jobs/build/okd-scan/README.md
@@ -22,7 +22,7 @@ This Jenkins job scans OKD image sources for changes and triggers OKD builds whe
 
 ## What It Does
 
-1. **Checks if version is enabled** - Exits early if version not in `OKD_ENABLED_VERSIONS`
+1. **Checks if version is enabled** - Exits early when `group.yml` `okd.enabled` is not true for the selected OCP version
 2. **Initializes environment** with proper credentials and workspace
 3. **Scans OKD images** using `artcd okd-scan` with `--variant=okd`
    - The `--variant=okd` flag tells doozer to skip checks not relevant for OKD:
@@ -95,3 +95,11 @@ If either lock is held, the job will skip execution.
 Pipeline implementation:
 - `pyartcd/pyartcd/pipelines/okd_scan.py`
 - `pyartcd/pyartcd/pipelines/scheduled/schedule_okd_scan.py`
+
+## Enabling OKD for a new OCP version
+
+1. Set `okd.enabled: true` under the `okd:` key in `group.yml` on the target `openshift-X.Y` branch in ocp-build-data.
+2. Merge the build-data change. Scheduled `schedule-okd-scan` and `okd-images-health` discover enabled versions from build-data automatically (no Jenkins list to update).
+3. Confirm Konflux OKD tenant/application config exists for the version before expecting scans or builds to succeed.
+
+Manual okd-scan/build jobs accept any OCP version in the parameter dropdown; pyartcd skips versions without `okd.enabled: true`.

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -26,14 +26,6 @@ ocp5Versions = [
     "5.0",
 ]
 
-
-okdVersions = [
-    "5.0",
-    "4.23",
-    "4.22",
-    "4.21",
-]
-
 nonOCPGroups = [
     "acm-2.16",
     "mce-2.11",
@@ -157,9 +149,9 @@ def ocpVersionParam(name='MINOR_VERSION', majorVersion='all', extraOpts=[]) {
 def okdVersionParam(name='VERSION', extraOpts=[]) {
     return [
         name: name,
-        description: 'OKD Version',
+        description: 'OKD Version (okd-scan skips versions without okd.enabled in build-data)',
         $class: 'hudson.model.ChoiceParameterDefinition',
-        choices: (extraOpts + okdVersions).join('\n'),
+        choices: (extraOpts + ocp5Versions + ocp4Versions).join('\n'),
     ]
 }
 

--- a/scheduled-jobs/build/okd_scan/Jenkinsfile
+++ b/scheduled-jobs/build/okd_scan/Jenkinsfile
@@ -28,9 +28,6 @@ node {
             "--config=./config/artcd.toml",
             "schedule-okd-scan"
         ]
-        for ( version in commonlib.okdVersions ) {
-            cmd << "--version=${version}"
-        }
 
         withCredentials([
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),

--- a/scheduled-jobs/scanning/okd-images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/okd-images-health/Jenkinsfile
@@ -19,7 +19,7 @@ node() {
             b = build(
                 job: '../scanning/scanning%2Fokd-images-health',
                 parameters: [
-                    string(name: 'VERSIONS', value: commonlib.okdVersions.join(',')),
+                    string(name: 'VERSIONS', value: ''),
                     booleanParam(name: 'SEND_TO_RELEASE_CHANNEL', value: true),
                     booleanParam(name: 'SEND_TO_OKD_CHANNEL', value: true),
                 ],


### PR DESCRIPTION
## Summary
Remove 4.23 from Jenkins OKD version lists and document build-data enablement workflow.

## Changes
- Drop 4.23 from `commonlib.groovy` `okdVersions` (scheduled okd-scan and okd-images-health fan-out)
- Update okd-scan README: enablement via `group.yml` `okd.enabled` plus Jenkins list sync

Pair with [ART-21084](https://redhat.atlassian.net/browse/ART-21084) art-tools and ocp-build-data changes.