### PR TITLE
Add SKIP_RPMS parameter to ocp4-scan-konflux job

### DIFF
--- a/jobs/build/ocp4-scan-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-scan-konflux/Jenkinsfile
@@ -49,6 +49,11 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                         trim: true,
                     ),
                     booleanParam(
+                        name: 'SKIP_RPMS',
+                        description: 'Skip loading RPMs (useful when repo cloning is not possible)',
+                        defaultValue: true,
+                    ),
+                    booleanParam(
                         name: 'DRY_RUN',
                         description: 'Run scan without triggering subsequent jobs',
                         defaultValue: false,
@@ -99,6 +104,9 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                 }
                 if (params.IMAGE_LIST) {
                     cmd << "--image-list=${commonlib.cleanCommaList(params.IMAGE_LIST)}"
+                }
+                if (params.SKIP_RPMS) {
+                    cmd << "--skip-rpms"
                 }
 
                 // Run pipeline


### PR DESCRIPTION
## Summary
- Adds a new `SKIP_RPMS` boolean parameter to the ocp4-scan-konflux Jenkins job
- Defaults to `true` to skip RPM loading since repos cannot currently be cloned
- Passes `--skip-rpms` flag to the artcd command when enabled

## Related
- Companion PR in art-tools: https://github.com/openshift-eng/art-tools/pull/3115

## Test plan
- [ ] Verify Jenkins job displays the new parameter
- [ ] Test that the `--skip-rpms` flag is properly passed to artcd when parameter is true
- [ ] Confirm job runs successfully without attempting to clone RPM repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)