### PR TITLE
Add 5.0 to publish-rpms version parameters

### DIFF
--- a/jobs/build/publish-rpms/Jenkinsfile
+++ b/jobs/build/publish-rpms/Jenkinsfile
@@ -26,7 +26,7 @@ node {
             [
                 $class : 'ParametersDefinitionProperty',
                 parameterDefinitions: [
-                    commonlib.ocpVersionParam('BUILD_VERSION', '4'),
+                    commonlib.ocpVersionParam('BUILD_VERSION', '4plus'),
                     choice(
                         name: 'ARCH',
                         description: 'architecture being synced',


### PR DESCRIPTION
## Summary
- Change major version selector from `'4'` to `'4plus'` in the publish-rpms job so that `5.0` is available in the `BUILD_VERSION` dropdown.

## Test plan
- [ ] Verify the publish-rpms job shows 5.0 in the BUILD_VERSION parameter dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)