### PR TITLE
publish-rpms: skip unavailable packages in dnf download

### DIFF
--- a/jobs/build/publish-rpms/collect_deps.py
+++ b/jobs/build/publish-rpms/collect_deps.py
@@ -147,6 +147,7 @@ async def download_rpms(ocp_version: str, arch: str, rhel_major: int, output_dir
             "-c", f"{yum_conf_filename}",
             "--disableplugin=subscription-manager",
             "--downloadonly",
+            "--skip-unavailable",
             #f"--installroot={Path(install_root_dir).absolute()}",
             f"--destdir={output_dir}",
             f"--forcearch={arch}",


### PR DESCRIPTION
Add `--skip-unavailable` to the `dnf download` command so packages absent from the configured repos (e.g. `runc` in OCP 5.0) are silently skipped rather than failing the job.