### PR TITLE
publish-rpms: use --skip-broken instead of --skip-unavailable

### DIFF
--- a/jobs/build/publish-rpms/collect_deps.py
+++ b/jobs/build/publish-rpms/collect_deps.py
@@ -147,7 +147,7 @@ async def download_rpms(ocp_version: str, arch: str, rhel_major: int, output_dir
             "-c", f"{yum_conf_filename}",
             "--disableplugin=subscription-manager",
             "--downloadonly",
-            "--skip-unavailable",
+            "--skip-broken",
             #f"--installroot={Path(install_root_dir).absolute()}",
             f"--destdir={output_dir}",
             f"--forcearch={arch}",


### PR DESCRIPTION
`--skip-unavailable` (introduced in https://github.com/openshift-eng/aos-cd-jobs/pull/4746) is a dnf5 option and not supported in dnf4. `--skip-broken` is the dnf4 equivalent that handles packages not found in the configured repos, allowing the job to succeed when packages like `runc` are absent in OCP 5.0 repos.