### PR TITLE
ART-21532: Pass version param to build-plashets job

### DIFF
--- a/jobs/build/build-plashets/Jenkinsfile
+++ b/jobs/build/build-plashets/Jenkinsfile
@@ -93,6 +93,11 @@ node {
                 currentBuild.description = ""
             }
 
+            // Validate that VERSION is provided for golang group
+            if (group == "golang" && !params.VERSION) {
+                error("VERSION parameter is required when building plashets for golang group")
+            }
+
         }
 
         stage("Build plashets") {

--- a/jobs/build/build-plashets/Jenkinsfile
+++ b/jobs/build/build-plashets/Jenkinsfile
@@ -81,6 +81,7 @@ node {
         commonlib.checkMock()
         def group = params.GROUP ?: "openshift-${params.VERSION}"
 
+
         stage("Initialize") {
             currentBuild.displayName = "${group} - ${params.RELEASE} - ${params.ASSEMBLY}"
 
@@ -122,6 +123,9 @@ node {
             }
             if (params.COPY_LINKS) {
                 cmd << "--copy-links"
+            }
+            if (params.VERSION) {
+                cmd << "--version=${params.VERSION}"
             }
 
             try {

--- a/jobs/build/build-plashets/Jenkinsfile
+++ b/jobs/build/build-plashets/Jenkinsfile
@@ -73,6 +73,11 @@ node {
                             description: 'Transform symlink into referent file/dir',
                             defaultValue: false,
                         ),
+                        booleanParam(
+                            name: 'OVERRIDE_OCP_VERSION',
+                            description: 'Substitute the ${MAJOR} and ${MINOR} in group.yaml based on the parameter VERSION',
+                            defaultValue: false,
+                        ),
                     ]
                 ],
             ]
@@ -92,10 +97,12 @@ node {
             if (currentBuild.description == null) {
                 currentBuild.description = ""
             }
-
+            if ( !params.OVERRIDE_OCP_VERSION || params.VERSION) {
+                error("If OVERRIDE_OCP_VERSION is set then VERSION has to be set as well")
+            }
             // Validate that VERSION is provided for golang group
-            if (group == "golang" && !params.VERSION) {
-                error("VERSION parameter is required when building plashets for golang group")
+            if (group == "golang" && !params.OVERRIDE_OCP_VERSION) {
+                error("The OCP Version has to be overriden in case of golang group: param VERSION, OVERRIDE_OCP_VERSION has te be set true")
             }
 
         }
@@ -128,6 +135,9 @@ node {
             }
             if (params.COPY_LINKS) {
                 cmd << "--copy-links"
+            }
+            if (params.OVERRIDE_OCP_VERSION) {
+                cmd << "--override_ocp_version"
             }
             if (params.VERSION) {
                 cmd << "--version=${params.VERSION}"

--- a/jobs/build/build-plashets/Jenkinsfile
+++ b/jobs/build/build-plashets/Jenkinsfile
@@ -73,11 +73,6 @@ node {
                             description: 'Transform symlink into referent file/dir',
                             defaultValue: false,
                         ),
-                        booleanParam(
-                            name: 'OVERRIDE_OCP_VERSION',
-                            description: 'Substitute the ${MAJOR} and ${MINOR} in group.yaml based on the parameter VERSION',
-                            defaultValue: false,
-                        ),
                     ]
                 ],
             ]
@@ -97,12 +92,9 @@ node {
             if (currentBuild.description == null) {
                 currentBuild.description = ""
             }
-            if ( !params.OVERRIDE_OCP_VERSION || params.VERSION) {
-                error("If OVERRIDE_OCP_VERSION is set then VERSION has to be set as well")
-            }
             // Validate that VERSION is provided for golang group
-            if (group == "golang" && !params.OVERRIDE_OCP_VERSION) {
-                error("The OCP Version has to be overriden in case of golang group: param VERSION, OVERRIDE_OCP_VERSION has te be set true")
+            if (group == "golang" && !params.VERSION) {
+                error("The OCP Version has to be set in case of golang group")
             }
 
         }
@@ -135,9 +127,6 @@ node {
             }
             if (params.COPY_LINKS) {
                 cmd << "--copy-links"
-            }
-            if (params.OVERRIDE_OCP_VERSION) {
-                cmd << "--override_ocp_version"
             }
             if (params.VERSION) {
                 cmd << "--version=${params.VERSION}"


### PR DESCRIPTION
## Summary
- Pass the `VERSION` parameter from the Jenkins job to the `artcd` command when building plashets
- If the group is `golang` it is obligatory parameter, because the `MAJOR` and `MINOR` version have to be substituted in `group.yaml`
- `art-tools` repository has to be prepared for this change