### PR TITLE
release-from-fbc: mark dry runs in the Jenkins build title

### DIFF
--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -89,6 +89,9 @@ node {
     sshagent(["openshift-bot"]) {
         stage("initialize") {
             currentBuild.displayName = "#${currentBuild.number} ${params.GROUP} ${params.ASSEMBLY}"
+            if (params.DRY_RUN) {
+                currentBuild.displayName += " [DRY_RUN]"
+            }
         }
 
         try {


### PR DESCRIPTION
## Summary
- Appends ` [DRY_RUN]` to the Jenkins build display name for the `release-from-fbc` job when `DRY_RUN` is enabled, so dry runs are visible at a glance in the build history.
- Matches the existing convention used by other Konflux jobs (`build-sync-konflux`, `ocp4-scan-konflux`, `build-sync`).

## Test plan
- [ ] Trigger `release-from-fbc` with `DRY_RUN=true` and confirm the build title shows the `[DRY_RUN]` suffix.
- [ ] Trigger `release-from-fbc` with `DRY_RUN=false` and confirm the build title is unchanged.

Made with [Cursor](https://cursor.com)