### PR TITLE
Retry R2 post-sync verification with increasing backoff

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -673,15 +673,25 @@ def verifySyncedToMirror(local_dir, s3_path, include_only='') {
     if (s3_out) {
         error("S3 post-sync verification failed -- files missing or size mismatch:\n${s3_out}")
     }
-    sleep(15)
-    def r2_out = sh(
-        script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
-        returnStdout: true
-    ).trim()
-    if (r2_out) {
-        error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
+
+    // R2 has eventual consistency; retry verification with increasing waits
+    def r2_waits = [15, 30, 60]
+    for (int i = 0; i < r2_waits.size(); i++) {
+        sleep(r2_waits[i])
+        def r2_out = sh(
+            script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
+            returnStdout: true
+        ).trim()
+        if (!r2_out) {
+            echo "Verified: all local files present in S3 and R2 for ${s3_path}"
+            return
+        }
+        if (i < r2_waits.size() - 1) {
+            echo "R2 verification attempt ${i + 1} found inconsistencies, retrying after longer wait:\n${r2_out}"
+        } else {
+            error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
+        }
     }
-    echo "Verified: all local files present in S3 and R2 for ${s3_path}"
 }
 
 def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, issue_cloudfront_invalidation=true, dry_run=false) {


### PR DESCRIPTION
## Summary
- `verifySyncedToMirror()` in `pipeline-scripts/commonlib.groovy` only waited a fixed 15s before checking Cloudflare R2 for post-sync consistency. When R2 metadata propagation lagged, the outer `retry(3)` burned through all 3 attempts (each re-uploading and re-verifying) within ~50 seconds total, which wasn't long enough for R2 to catch up.
- This was observed causing a false-positive failure of `build/butane_sync` build #14 (`R2 post-sync verification failed -- files missing or size mismatch` for a file that was, in fact, already correctly uploaded).
- The R2 dryrun check is now retried in place (without re-uploading) with increasing waits of 15s, 30s, and 60s before failing, giving R2 substantially more time (~105s total) to become consistent.
- The happy path (R2 already consistent) is unaffected — it still passes after the first 15s wait, same as before.
- Both `syncDirToS3Mirror()` and `syncRepoToS3Mirror()` call `verifySyncedToMirror()`, so both benefit from this change.

## Test plan
- [ ] Re-run `build/butane_sync` (or another job using `syncDirToS3Mirror`/`syncRepoToS3Mirror`) and confirm it completes successfully
- [ ] Manually review the Groovy syntax in `pipeline-scripts/commonlib.groovy` for correctness (no CI test suite exercises Jenkins shared library Groovy directly)
