### PR TITLE
Verify R2 mismatches via HeadObject instead of longer backoff waits

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -679,7 +679,21 @@ def verifySyncedToMirror(local_dir, s3_path, include_only='') {
         returnStdout: true
     ).trim()
     if (r2_out) {
-        error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
+        // aws s3 sync's dryrun check determines mismatches via ListObjectsV2, whose consistency
+        // on Cloudflare R2 can lag behind the object store itself -- HeadObject/GetObject reflect
+        // the true current state much sooner. Re-check flagged files directly via HeadObject
+        // before failing the build on what may be a stale listing.
+        echo "R2 dryrun flagged inconsistencies, double-checking with HeadObject before failing:\n${r2_out}"
+        writeFile file: '.r2_dryrun_out.txt', text: r2_out
+        def real_mismatches = sh(
+            script: 'bash pipeline-scripts/verify-r2-head-objects.sh .r2_dryrun_out.txt',
+            returnStdout: true
+        ).trim()
+        sh 'rm -f .r2_dryrun_out.txt'
+        if (real_mismatches) {
+            error("R2 post-sync verification failed -- files missing or size mismatch:\n${real_mismatches}")
+        }
+        echo "R2 dryrun mismatch was a stale ListObjectsV2 listing; HeadObject confirms objects are correct."
     }
     echo "Verified: all local files present in S3 and R2 for ${s3_path}"
 }

--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -673,25 +673,15 @@ def verifySyncedToMirror(local_dir, s3_path, include_only='') {
     if (s3_out) {
         error("S3 post-sync verification failed -- files missing or size mismatch:\n${s3_out}")
     }
-
-    // R2 has eventual consistency; retry verification with increasing waits
-    def r2_waits = [15, 30, 60]
-    for (int i = 0; i < r2_waits.size(); i++) {
-        sleep(r2_waits[i])
-        def r2_out = sh(
-            script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
-            returnStdout: true
-        ).trim()
-        if (!r2_out) {
-            echo "Verified: all local files present in S3 and R2 for ${s3_path}"
-            return
-        }
-        if (i < r2_waits.size() - 1) {
-            echo "R2 verification attempt ${i + 1} found inconsistencies, retrying after longer wait:\n${r2_out}"
-        } else {
-            error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
-        }
+    sleep(15)
+    def r2_out = sh(
+        script: "aws s3 sync --no-progress --size-only --dryrun ${filter_args} ${local_dir} s3://art-srv-enterprise${s3_path} --profile cloudflare --endpoint-url ${env.CLOUDFLARE_ENDPOINT}",
+        returnStdout: true
+    ).trim()
+    if (r2_out) {
+        error("R2 post-sync verification failed -- files missing or size mismatch:\n${r2_out}")
     }
+    echo "Verified: all local files present in S3 and R2 for ${s3_path}"
 }
 
 def syncRepoToS3Mirror(local_dir, s3_path, remove_old=true, timeout_minutes=60, issue_cloudfront_invalidation=true, dry_run=false) {

--- a/pipeline-scripts/verify-r2-head-objects.sh
+++ b/pipeline-scripts/verify-r2-head-objects.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Re-checks files flagged by `aws s3 sync --dryrun` against Cloudflare R2 using HeadObject.
+#
+# `aws s3 sync --dryrun` determines mismatches via ListObjectsV2. On Cloudflare R2, that
+# listing can lag behind the object store itself for a period of time after an upload,
+# even though HeadObject/GetObject already reflect the correct, current object. This
+# produces false-positive "missing or size mismatch" verification failures.
+#
+# Reads dryrun output lines from the file given as $1 (one per line, in the format
+# produced by `aws s3 sync --dryrun`) and prints only the lines that are still genuinely
+# mismatched after directly re-checking the object via HeadObject.
+set -euo pipefail
+
+dryrun_file="$1"
+bucket="art-srv-enterprise"
+
+while IFS= read -r line; do
+    case "$line" in
+        "(dryrun) upload:"*)
+            local_path=$(echo "$line" | sed -E 's/^\(dryrun\) upload: //; s/ to s3:\/\/.*$//')
+            key=$(echo "$line" | sed -E 's#.* to s3://[^/]+/##')
+            # -L dereferences symlinks so the target's size is reported, not the link's own size.
+            local_size=$(stat -Lc%s "$local_path" 2>/dev/null || stat -Lf%z "$local_path" 2>/dev/null || echo -1)
+            remote_size=$(aws s3api head-object --bucket "$bucket" --key "$key" \
+                --profile cloudflare --endpoint-url "${CLOUDFLARE_ENDPOINT}" \
+                --query ContentLength --output text 2>/dev/null || echo MISSING)
+            if [ "$remote_size" != "$local_size" ]; then
+                echo "${line} (head-object confirms: local=${local_size} remote=${remote_size})"
+            fi
+            ;;
+        *)
+            # Any other dryrun action (e.g. an unexpected extra remote file staged for
+            # deletion) can't be disambiguated by a HeadObject check -- treat as a real mismatch.
+            echo "$line"
+            ;;
+    esac
+done < "$dryrun_file"


### PR DESCRIPTION
## Summary
- Reverts #4755 ("Retry R2 post-sync verification with increasing backoff"). That fix addressed the wrong root cause: `build/butane_sync#16` still failed after the full 15s/30s/60s backoff x 3 retries (~5.5 minutes total), always on the same key (`v0.29.0-1/butane`).
- Runtime evidence: immediately after that failed build, a direct `aws s3api head-object` against the R2 object showed it already had the correct `ContentLength` (10604480) and the file downloaded from R2 matched the expected SHA256 exactly. The object itself was correct the whole time.
- Actual root cause: `aws s3 sync --dryrun` determines mismatches via `ListObjectsV2`, and on Cloudflare R2 that listing can lag behind the object store itself for longer than any reasonable fixed/backoff wait -- while `HeadObject`/`GetObject` already reflect the correct, current object.
- Fix: when the R2 dryrun check flags files, re-check each flagged file directly via `HeadObject` (`pipeline-scripts/verify-r2-head-objects.sh`) before failing the build. Only flagged files are re-checked (not every file), so this stays cheap for `syncRepoToS3Mirror()` callers with large file counts (RPM repos, etc.).
- The new script also had to explicitly dereference symlinks (`stat -L`) when computing local file size -- confirmed via a local functional test that a naive `stat` call reproduces the exact same false-mismatch bug this PR is fixing, since `butane` is a symlink to `butane-amd64` and plain `stat` reports the symlink's own (tiny) size rather than the target's real size.

## Test plan
- [x] Local functional test of `verify-r2-head-objects.sh` against synthetic dryrun output covering: false-positive (remote correct), genuine size mismatch, and missing object -- confirmed correct behavior in all three cases, and confirmed the symlink-size bug before fixing it with `stat -L`.
- [ ] Re-run `build/butane_sync` and confirm it completes successfully end to end.
