### PR TITLE
USE_NEW_GOLANG_BRANCH param true by default in golang builder pipeline

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -81,7 +81,7 @@ node {
                     booleanParam(
                         name: 'USE_NEW_GOLANG_BRANCH',
                         description: 'Use the unified "golang" branch layout in ocp-build-data instead of per-variant branches (e.g. rhel-9-golang-1.26).',
-                        defaultValue: false,
+                        defaultValue: true,
                     ),
                     booleanParam(
                         name: 'MAJOR_BUMP',


### PR DESCRIPTION
Setting param `USE_NEW_GOLANG_BRANCH` to true in **golang builder** pipeline. It will use the new branch: 
https://github.com/openshift-eng/ocp-build-data/tree/golang
by default

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED