### PR TITLE
Add oc-mirror-2.0 to nonOCPGroups

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -50,6 +50,7 @@ nonOCPGroups = [
     "oadp-1.4",
     "oadp-1.5",
     "oadp-1.6",
+    "oc-mirror-2.0",
 ]
 
 ocpVersions = ocp5Versions + ocp4Versions + ocp3Versions


### PR DESCRIPTION
Adds oc-mirror-2.0 to the list of non-OCP groups for build tracking.