### PR TITLE
ART-21693: add OCP 5.1 version

### DIFF
--- a/pipeline-scripts/commonlib.groovy
+++ b/pipeline-scripts/commonlib.groovy
@@ -23,6 +23,7 @@ ocp4Versions = [
 
 // All buildable versions of ocp5
 ocp5Versions = [
+    "5.1",
     "5.0",
 ]
 


### PR DESCRIPTION
Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED