### PR TITLE
ART-20930: add golang-builder-shipment Jenkins jobs

### DIFF
--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -195,18 +195,8 @@ Build URL: ${BUILD_URL}
         stage("Golang builder shipment") {
             if (env.BASE_IMAGE_RELEASE_NVR ==~ /openshift-golang-builder-container-.*/) {
                 echo "Detected golang builder NVR: ${env.BASE_IMAGE_RELEASE_NVR}"
-                // Derive group from NVR: openshift-golang-builder-container-v1.25.x-....el9 -> rhel-9-golang-1.25
-                def goMinorMatch = (env.BASE_IMAGE_RELEASE_NVR =~ /container-v(\d+\.\d+)\./)
-                def rhelMatch = (env.BASE_IMAGE_RELEASE_NVR =~ /\.el(\d+)/)
-                if (!goMinorMatch || !rhelMatch) {
-                    error("Cannot derive golang group from NVR: ${env.BASE_IMAGE_RELEASE_NVR}")
-                }
-                def goMinor = goMinorMatch[0][1]
-                def rhelNum = rhelMatch[0][1]
-                def golangGroup = "rhel-${rhelNum}-golang-${goMinor}"
-                echo "Derived golang group: ${golangGroup}"
 
-                def shipmentCmd = ["doozer", "--group", golangGroup, "--working-dir", doozer_working]
+                def shipmentCmd = ["doozer", "--group", "golang", "--working-dir", doozer_working]
                 if (params.DOOZER_DATA_PATH) {
                     def dataPath = params.DOOZER_DATA_GITREF ?
                         "${params.DOOZER_DATA_PATH}@${params.DOOZER_DATA_GITREF}" :

--- a/jobs/build/base-image-release/Jenkinsfile
+++ b/jobs/build/base-image-release/Jenkinsfile
@@ -14,6 +14,10 @@ node() {
         Supply exactly one Konflux IMAGE build <code>NVR</code> (SUCCESS row required for this group —
         ART-18934 / art-tools). The job invokes <code>doozer images:release-to-base-repo</code>
         once with singular <code>--nvr</code>.
+
+        For <code>rhel-*-golang-*</code> build groups, the job also runs
+        <code>doozer golang-builder-shipment</code> after release to create a shipment MR in
+        <code>ocp-shipment-data</code>.
     """)
 
     properties([
@@ -66,6 +70,11 @@ node() {
                     description: 'When true, invoke doozer with global --dry-run. Snapshot/release semantics for images:release-to-base-repo depend on art-tools honoring that flag; confirm behavior before trusting it for risky runs.',
                     defaultValue: false,
                 ),
+                booleanParam(
+                    name: 'SKIP_LEGACY_RELEASE',
+                    description: 'Skip the images:release-to-base-repo stage entirely. Use to test the golang-builder-shipment stage in isolation without triggering a real base-image release.',
+                    defaultValue: false,
+                ),
             ],
         ]
     ])
@@ -105,6 +114,9 @@ node() {
         doozer_working = "${env.WORKSPACE}/doozer_working"
         buildlib.cleanWorkdir(doozer_working)
 
+        if (params.SKIP_LEGACY_RELEASE) {
+            echo "SKIP_LEGACY_RELEASE=true — skipping images:release-to-base-repo"
+        } else {
         try {
             def cmd = [
                 "doozer",
@@ -177,6 +189,43 @@ Build URL: ${BUILD_URL}
                 "doozer_working/**/*.json",
             ])
             buildlib.cleanWorkspace()
+        }
+        } // end else SKIP_LEGACY_RELEASE
+
+        stage("Golang builder shipment") {
+            if (env.BASE_IMAGE_RELEASE_NVR ==~ /openshift-golang-builder-container-.*/) {
+                echo "Detected golang builder NVR: ${env.BASE_IMAGE_RELEASE_NVR}"
+                // Derive group from NVR: openshift-golang-builder-container-v1.25.x-....el9 -> rhel-9-golang-1.25
+                def goMinorMatch = (env.BASE_IMAGE_RELEASE_NVR =~ /container-v(\d+\.\d+)\./)
+                def rhelMatch = (env.BASE_IMAGE_RELEASE_NVR =~ /\.el(\d+)/)
+                if (!goMinorMatch || !rhelMatch) {
+                    error("Cannot derive golang group from NVR: ${env.BASE_IMAGE_RELEASE_NVR}")
+                }
+                def goMinor = goMinorMatch[0][1]
+                def rhelNum = rhelMatch[0][1]
+                def golangGroup = "rhel-${rhelNum}-golang-${goMinor}"
+                echo "Derived golang group: ${golangGroup}"
+
+                def shipmentCmd = ["doozer", "--group", golangGroup, "--working-dir", doozer_working]
+                if (params.DOOZER_DATA_PATH) {
+                    def dataPath = params.DOOZER_DATA_GITREF ?
+                        "${params.DOOZER_DATA_PATH}@${params.DOOZER_DATA_GITREF}" :
+                        params.DOOZER_DATA_PATH
+                    shipmentCmd += ["--data-path", dataPath]
+                }
+                shipmentCmd += ["golang-builder-shipment", env.BASE_IMAGE_RELEASE_NVR]
+                echo "Will run: ${shipmentCmd.join(' ')}"
+                withCredentials([
+                    string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
+                    file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
+                    file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                    file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                ]) {
+                    sh(script: shipmentCmd.join(' '))
+                }
+            } else {
+                echo "Not a golang builder NVR, skipping shipment MR creation"
+            }
         }
     }
 

--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -122,7 +122,7 @@ node {
         stage('Build golang-builder images') {
             def golang_nvrs = commonlib.cleanSpaceList(params.GOLANG_NVRS)
             withCredentials([
-                string(credentialsId: 'gitlab-ocp-release-schedule-schedule', variable: 'GITLAB_TOKEN'),
+                string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
                 string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                 string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                 string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),


### PR DESCRIPTION
## What

Adds Jenkins job support for the `artcd golang-builder-shipment` pipeline (art-tools openshift-eng/art-tools#3231).

**New job:** `jobs/build/golang-builder-shipment/Jenkinsfile`
Standalone job to create shipment MRs in ocp-shipment-data on demand.
Accepts `GOLANG_NVRS` (auto-resolves Konflux NVRs and golang group) or explicit `IMAGE_NVRS`.

**Updated job:** `jobs/build/golang-builder/Jenkinsfile`
Adds opt-in `CREATE_SHIPMENT` boolean — when enabled, triggers `artcd golang-builder-shipment` after the build completes.

## Why

Part of [ART-20920](https://redhat.atlassian.net/browse/ART-20920): moving golang builders from silent auto-release to
shipment-gated ERT-approved delivery via `ocp-art-golang-builder-{prod,ec}-rhel9` RPAs.

## Jira

https://redhat.atlassian.net/browse/ART-20930

## Notes

Supersedes the trigger portion of a prior branch that had accumulated unrelated
`sync-ci-images` and `commonlib.groovy` changes. This PR is scoped to [ART-20930](https://redhat.atlassian.net/browse/ART-20930) only.