### PR TITLE
ART-21533: Run periodic conforma-verify jobs in parallel

### DIFF
--- a/scheduled-jobs/build/conforma_verify/Jenkinsfile
+++ b/scheduled-jobs/build/conforma_verify/Jenkinsfile
@@ -32,8 +32,6 @@ node {
         for ( version in commonlib.ocpMajorVersions["4plus"] ) {
             cmd << "--version=${version}"
         }
-        cmd << "--serial"
-
         withCredentials([
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),


### PR DESCRIPTION
Remove `--serial` flag so all OCP versions run their conforma-verify jobs concurrently instead of sequentially.