### PR TITLE
Add assembly parameter to Golang builder job

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -68,6 +68,11 @@ node {
                         choices: ['both', 'brew', 'konflux'],
                         description: 'Build system to use for golang-builder images (brew, konflux, or both). Defaults to both.',
                     ),
+                    choice(
+                        name: 'ASSEMBLY',
+                        choices: ['stream', 'test'],
+                        description: 'Stream-type assembly to use for golang-builder operations. Defaults to stream.',
+                    ),
                     booleanParam(
                         name: 'SKIP_PR',
                         description: 'Skip PR generation for ocp-build-data updates.',
@@ -181,6 +186,7 @@ node {
                         if (params.BUILD_SYSTEM) {
                             cmd << "--build-system=${params.BUILD_SYSTEM}"
                         }
+                        cmd << "--assembly=${params.ASSEMBLY}"
                         if (params.SKIP_PR) {
                             cmd << "--skip-pr"
                         }


### PR DESCRIPTION
## Summary

- add an ASSEMBLY choice parameter with stream and test options
- pass the selected value to artcd update-golang with --assembly

## Why

The update-golang pipeline now supports stream-type assemblies, but the Jenkins job did not expose the CLI option. This change lets users select test while keeping stream as the first and default choice.

Compatibility validation remains in art-tools; the Jenkins job only exposes and forwards the parameter.

## Validation

- repository pre-commit checks passed
- git diff --check

## Dependencies

- openshift-eng/art-tools#3251
- openshift-eng/ocp-build-data#12202