### PR TITLE
Add release-payload Jenkins job

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -131,24 +131,6 @@ node() {
                     }
                 }
             }
-        } catch (err) {
-            commonlib.email(
-                to: "aos-art-automation+failed-release-payload@redhat.com",
-                from: "aos-art-automation@redhat.com",
-                replyTo: "aos-team-art@redhat.com",
-                subject: "Error during release-payload (${params.VERSION} - ${params.ASSEMBLY})",
-                body: """
-There was an error building the release payload:
-
-  Group:           openshift-${params.VERSION}
-  Assembly:        ${params.ASSEMBLY}
-  Payload version: ${payloadVersion}
-  Payload release: ${payloadRelease}
-  Error:           ${err}
-
-Build URL: ${BUILD_URL}
-""")
-            throw err
         } finally {
             commonlib.safeArchiveArtifacts([
                 "doozer_working/debug.log",

--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -1,0 +1,163 @@
+#!/usr/bin/env groovy
+
+node() {
+    timestamps {
+
+    checkout scm
+    def buildlib = load("pipeline-scripts/buildlib.groovy")
+    def commonlib = buildlib.commonlib
+
+    commonlib.describeJob("release-payload", """
+        <h2>Build OpenShift release payload images in Konflux</h2>
+        <b>Timing</b>: Triggered automatically by promote-assembly after a successful promote.
+        Can also be triggered manually.
+
+        Invokes <code>doozer beta:release-payload:rebase-and-build</code> to rebase
+        the release payload source repo and trigger a Konflux build that produces a
+        multi-arch manifest-list image.
+    """)
+
+    properties([
+        disableResume(),
+        buildDiscarder(
+            logRotator(
+                artifactDaysToKeepStr: '30',
+                daysToKeepStr: '30',
+                numToKeepStr: '300',
+            )
+        ),
+        [
+            $class: 'ParametersDefinitionProperty',
+            parameterDefinitions: [
+                commonlib.ocpVersionParam('VERSION', '4plus'),
+                commonlib.artToolsParam(),
+                string(
+                    name: 'ASSEMBLY',
+                    description: 'Assembly name to build the release payload for (e.g. 4.21.1 or stream).',
+                    defaultValue: 'stream',
+                    trim: true,
+                ),
+                string(
+                    name: 'PAYLOAD_VERSION',
+                    description: '(Optional) Semver version string for the release payload NVR (e.g. 4.21.1). Defaults to the ASSEMBLY value when left blank.',
+                    defaultValue: '',
+                    trim: true,
+                ),
+                string(
+                    name: 'PAYLOAD_RELEASE',
+                    description: '(Optional) Release string for the release payload NVR (e.g. 202608011200.p0). Auto-generated from current UTC time when left blank.',
+                    defaultValue: '',
+                    trim: true,
+                ),
+                commonlib.dryrunParam('Do not push to git or trigger a Konflux build. Manifests are generated locally only.'),
+                commonlib.mockParam(),
+            ],
+        ]
+    ])
+
+    commonlib.checkMock()
+
+    def payloadVersion = params.PAYLOAD_VERSION?.trim() ?: params.ASSEMBLY
+    def payloadRelease = params.PAYLOAD_RELEASE?.trim() ?: new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone('UTC')) + ".p0"
+
+    currentBuild.displayName += " ${params.VERSION} - ${params.ASSEMBLY}"
+    if (params.DRY_RUN) {
+        currentBuild.displayName += " [DRY RUN]"
+    }
+
+    stage("Validate parameters") {
+        if (!params.VERSION?.trim()) {
+            error("VERSION is required")
+        }
+        if (!params.ASSEMBLY?.trim()) {
+            error("ASSEMBLY is required")
+        }
+        echo "Will build release payload:"
+        echo "  group:           openshift-${params.VERSION}"
+        echo "  assembly:        ${params.ASSEMBLY}"
+        echo "  payload version: ${payloadVersion}"
+        echo "  payload release: ${payloadRelease}"
+        echo "  dry run:         ${params.DRY_RUN}"
+    }
+
+    stage("Version dumps") {
+        buildlib.doozer "--version"
+        buildlib.oc("version --client=true -o yaml")
+    }
+
+    def doozer_working = "${env.WORKSPACE}/doozer_working"
+
+    stage("Build release payload") {
+        buildlib.cleanWorkdir(doozer_working)
+
+        def cmd = [
+            "doozer",
+            "--group", "openshift-${params.VERSION}",
+            "--assembly", params.ASSEMBLY,
+        ]
+
+        if (params.DRY_RUN) {
+            cmd << "--dry-run"
+        }
+
+        cmd += [
+            "beta:release-payload:rebase-and-build",
+            "--version", payloadVersion,
+            "--release", payloadRelease,
+        ]
+
+        if (!params.DRY_RUN) {
+            cmd << "--push"
+        }
+
+        echo "Will run: ${cmd.join(' ')}"
+
+        try {
+            dir(doozer_working) {
+                buildlib.withAppCiAsArtPublish() {
+                    withCredentials([
+                        file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
+                        file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                        string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                        usernamePassword(
+                            credentialsId: 'art-dash-db-login',
+                            passwordVariable: 'DOOZER_DB_PASSWORD',
+                            usernameVariable: 'DOOZER_DB_USER'
+                        ),
+                    ]) {
+                        withEnv(['DOOZER_DB_NAME=art_dash', "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
+                            sh(script: cmd.join(' '))
+                        }
+                    }
+                }
+            }
+        } catch (err) {
+            commonlib.email(
+                to: "aos-art-automation+failed-release-payload@redhat.com",
+                from: "aos-art-automation@redhat.com",
+                replyTo: "aos-team-art@redhat.com",
+                subject: "Error during release-payload (${params.VERSION} - ${params.ASSEMBLY})",
+                body: """
+There was an error building the release payload:
+
+  Group:           openshift-${params.VERSION}
+  Assembly:        ${params.ASSEMBLY}
+  Payload version: ${payloadVersion}
+  Payload release: ${payloadRelease}
+  Error:           ${err}
+
+Build URL: ${BUILD_URL}
+""")
+            throw err
+        } finally {
+            commonlib.safeArchiveArtifacts([
+                "doozer_working/debug.log",
+                "doozer_working/**/*.log",
+                "doozer_working/**/*.json",
+            ])
+            buildlib.cleanWorkspace()
+        }
+    }
+
+    }
+}

--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -117,7 +117,6 @@ node() {
                 buildlib.withAppCiAsArtPublish() {
                     withCredentials([
                         file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
-                        file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                         string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                         file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                         usernamePassword(

--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -118,7 +118,8 @@ node() {
                     withCredentials([
                         file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
                         file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
-                        string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
+                        string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
+                        file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                         usernamePassword(
                             credentialsId: 'art-dash-db-login',
                             passwordVariable: 'DOOZER_DB_PASSWORD',


### PR DESCRIPTION
## Summary

- Adds `jobs/build/release-payload/Jenkinsfile`, a new Jenkins job that wraps `doozer beta:release-payload:rebase-and-build` to build OpenShift release payload images in Konflux
- The job can be triggered manually for testing/reruns, or will be fired automatically (fire-and-forget) by the promote-assembly job in a follow-up PR
- Follows the same pattern as `base-image-release` for direct doozer invocation and credential management

## Parameters

| Parameter | Description |
|---|---|
| `VERSION` | OCP minor version (e.g. 4.21) |
| `ASSEMBLY` | Assembly name (e.g. 4.21.1 or stream) |
| `PAYLOAD_VERSION` | Optional semver for NVR `--version`; defaults to `ASSEMBLY` |
| `PAYLOAD_RELEASE` | Optional release string for NVR `--release`; auto-generated from UTC timestamp when blank |
| `DRY_RUN` | Generate manifests locally only, no git push or Konflux build |

## Test plan

- [ ] Trigger job manually with `DRY_RUN=true` and verify manifests are generated without pushing
- [ ] Trigger job manually without `DRY_RUN` and verify git push to `openshift-priv/ocp-release-payloads` and Konflux PipelineRun are initiated

## Related

- art-tools PR: https://github.com/openshift-eng/art-tools/pull/3218
- Follow-up: add fire-and-forget trigger from promote-assembly job

🤖 Generated with [Claude Code](https://claude.com/claude-code)