### PR TITLE
release-payload: fix --dry-run flag placement

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -96,17 +96,15 @@ node() {
             "--assembly", params.ASSEMBLY,
         ]
 
-        if (params.DRY_RUN) {
-            cmd << "--dry-run"
-        }
-
         cmd += [
             "beta:release-payload:rebase-and-build",
             "--version", payloadVersion,
             "--release", payloadRelease,
         ]
 
-        if (!params.DRY_RUN) {
+        if (params.DRY_RUN) {
+            cmd << "--dry-run"
+        } else {
             cmd << "--push"
         }
 


### PR DESCRIPTION
## Summary

- Move `--dry-run` to after the subcommand name — it is defined on `beta:release-payload:rebase-and-build`, not as a global doozer flag. Click was raising an error because doozer has no global `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)