### PR TITLE
release-payload: add PAYLOAD_VERSION param

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -37,6 +37,12 @@ node() {
                     defaultValue: 'stream',
                     trim: true,
                 ),
+                string(
+                    name: 'PAYLOAD_VERSION',
+                    description: '(Optional) Semver version string for the release payload NVR (e.g. 4.21.1). Defaults to the ASSEMBLY value when left blank.',
+                    defaultValue: '',
+                    trim: true,
+                ),
                 commonlib.dryrunParam('Do not push to git or trigger a Konflux build. Manifests are generated locally only.'),
                 commonlib.mockParam(),
             ],
@@ -45,7 +51,7 @@ node() {
 
     commonlib.checkMock()
 
-    def payloadVersion = params.ASSEMBLY
+    def payloadVersion = params.PAYLOAD_VERSION?.trim() ?: params.ASSEMBLY
     def payloadRelease = new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone('UTC')) + ".p0"
 
     currentBuild.displayName += " ${params.VERSION} - ${params.ASSEMBLY}"


### PR DESCRIPTION
## Summary

Adds an optional `PAYLOAD_VERSION` parameter to the `release-payload` job.

When set, it overrides the semver version string passed to `doozer beta:release-payload:rebase-and-build --version`. When left blank, it defaults to the `ASSEMBLY` value (which is correct for standard releases where the assembly name equals the version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)