### PR TITLE
Add quay-auth-file credential to release-payload job

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -94,6 +94,7 @@ node() {
             "beta:release-payload:rebase-and-build",
             "--version", payloadVersion,
             "--release", payloadRelease,
+            "--registry-config", '${QUAY_AUTH_FILE}',
         ]
 
         if (params.DRY_RUN) {

--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -116,6 +116,7 @@ node() {
                             passwordVariable: 'DOOZER_DB_PASSWORD',
                             usernameVariable: 'DOOZER_DB_USER'
                         ),
+                        file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                     ]) {
                         withEnv(['DOOZER_DB_NAME=art_dash', "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
                             sh(script: cmd.join(' '))


### PR DESCRIPTION
## Summary
- Adds `quay-auth-file` credential to the `withCredentials` block in the `release-payload` Jenkinsfile, consistent with how it is used in `promote-assembly`

## Test plan
- Trigger `release-payload` job manually and verify `QUAY_AUTH_FILE` is available in the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)