### PR TITLE
Add GOOGLE_APPLICATION_CREDENTIALS to release-payload job

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -118,6 +118,7 @@ node() {
                             usernameVariable: 'DOOZER_DB_USER'
                         ),
                         file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
+                        file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     ]) {
                         withEnv(['DOOZER_DB_NAME=art_dash', "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
                             sh(script: cmd.join(' '))


### PR DESCRIPTION
## Summary
- Adds `konflux-gcp-app-creds-prod` credential as `GOOGLE_APPLICATION_CREDENTIALS` to the `release-payload` Jenkinsfile, consistent with other build jobs

## Test plan
- Trigger `release-payload` job manually and verify `GOOGLE_APPLICATION_CREDENTIALS` is available in the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)