### PR TITLE
[ART-21960] Default SKIP_PRS=true for sync-ci-images

### DIFF
--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -56,8 +56,8 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                         ),
                         booleanParam(
                             name: 'SKIP_PRS',
-                            description: 'Do not create or update PRs for buildconfigs',
-                            defaultValue: false,
+                            description: 'Do not create or update PRs for buildconfigs (default: true, PRs now handled by open-reconciliation-prs pipeline)',
+                            defaultValue: true,
                         ),
                         booleanParam(
                             name: 'SKIP_WAITS',


### PR DESCRIPTION
## Summary
- Default `SKIP_PRS` to `true` in sync-ci-images Jenkins job
- Reconciliation PRs are now handled by the dedicated `open-reconciliation-prs` pipeline (openshift-eng/art-tools#3258)

## Merge order
- This PR should merge **before** openshift-eng/art-tools#TBD (which removes PR code from `sync_ci_images.py`)
- Safe to merge independently — worst case sync-ci-images just skips PRs by default, which is the desired state

## Test plan
- [ ] Verify sync-ci-images job defaults to SKIP_PRS=true
- [ ] Verify manual override to SKIP_PRS=false still works during transition