### PR TITLE
layered-products: use konflux SA for ASSISTED_INSTALLER_SA_KUBECONFIG

### DIFF
--- a/jobs/build/layered-products/Jenkinsfile
+++ b/jobs/build/layered-products/Jenkinsfile
@@ -170,7 +170,7 @@ node {
                             file(credentialsId: 'konflux-bot-0-art-oap-tenant-sa', variable: 'OAP_KONFLUX_SA_KUBECONFIG'),
                             file(credentialsId: 'konflux-bot-0-art-quay-tenant-sa', variable: 'QUAY_KONFLUX_SA_KUBECONFIG'),
                             file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
-                            file(credentialsId: 'openshift-bot-assisted-installer-service-account', variable: 'ASSISTED_INSTALLER_SA_KUBECONFIG'),
+                            file(credentialsId: 'konflux-bot-0-art-installer-agent-tenant-sa', variable: 'ASSISTED_INSTALLER_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
                             string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),


### PR DESCRIPTION
## Summary
- Replace `openshift-bot-assisted-installer-service-account` with `konflux-bot-0-art-installer-agent-tenant-sa` for `ASSISTED_INSTALLER_SA_KUBECONFIG` in `jobs/build/layered-products/Jenkinsfile`
- Aligns assisted-installer credential with the Konflux-based SA pattern used by all other credentials in this job (OADP, MTA, MTC, logging, ACM, OAP, Quay)

## Test plan
- [ ] Verify `konflux-bot-0-art-installer-agent-tenant-sa` credential exists in Jenkins
- [ ] Trigger a layered-products build that exercises the assisted-installer path and confirm it authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)