### PR TITLE
ART-22724: images-health: add PING_CHAI_BOT parameter

### DIFF
--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -55,6 +55,11 @@ node() {
                         trim: true,
                     ),
                     booleanParam(
+                        name: 'PING_CHAI_BOT',
+                        defaultValue: true,
+                        description: "If true, notify chai-bot in #team-art-chai-bot for multi-failure images"
+                    ),
+                    booleanParam(
                         name: 'JIRA',
                         defaultValue: true,
                         description: "If true, create/close Jira tickets for build failures"
@@ -100,6 +105,9 @@ node() {
     }
     if (params.PUBLIC_CHANNEL) {
         cmd << "--send-to-public-channel=${params.PUBLIC_CHANNEL}"
+    }
+    if (params.PING_CHAI_BOT) {
+        cmd << "--ping-chai-bot"
     }
     if (params.JIRA) {
         cmd << "--sync-jira"

--- a/scheduled-jobs/scanning/images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/images-health/Jenkinsfile
@@ -21,6 +21,7 @@ node() {
                 parameters: [
                     booleanParam(name: 'SEND_TO_RELEASE_CHANNEL', value: true),
                     string(name: 'PUBLIC_CHANNEL', value: '#forum-ocp-art'),
+                    booleanParam(name: 'PING_CHAI_BOT', value: true),
                 ],
                 propagate: false,
             )


### PR DESCRIPTION
## Summary

- Adds `PING_CHAI_BOT` boolean parameter (default: `true`) to the `images-health` job Jenkinsfile, mirroring the same parameter added to `okd-images-health` in #4781
- Passes `--ping-chai-bot` flag to `artcd images-health` when enabled
- Scheduled job Jenkinsfile passes `PING_CHAI_BOT: true` explicitly

## Test plan
- [ ] Trigger `images-health` manually with `PING_CHAI_BOT=true` and verify chai-bot receives notification in `#team-art-chai-bot` for any multi-failure images
- [ ] Trigger with `PING_CHAI_BOT=false` and verify no chai-bot message is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)