### PR TITLE
Add SYNC parameter to release-payload job

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -44,6 +44,11 @@ node() {
                     trim: true,
                 ),
                 commonlib.dryrunParam('Do not push to git or trigger a Konflux build. Manifests are generated locally only.'),
+                booleanParam(
+                    name: 'SYNC',
+                    description: 'After a successful build, mirror the release payload manifest list and every per-arch image to quay.io/openshift-release-dev/ocp-release (each pinned by its own sha256-<digest> tag). Requires a non-dry-run build (uses --push).',
+                    defaultValue: false,
+                ),
                 commonlib.mockParam(),
             ],
         ]
@@ -57,6 +62,9 @@ node() {
     currentBuild.displayName += " ${params.VERSION} - ${params.ASSEMBLY}"
     if (params.DRY_RUN) {
         currentBuild.displayName += " [DRY RUN]"
+    }
+    if (params.SYNC) {
+        currentBuild.displayName += " [SYNC]"
     }
 
     stage("Validate parameters") {
@@ -72,6 +80,7 @@ node() {
         echo "  payload version: ${payloadVersion}"
         echo "  payload release: ${payloadRelease}"
         echo "  dry run:         ${params.DRY_RUN}"
+        echo "  sync:            ${params.SYNC}"
     }
 
     stage("Version dumps") {
@@ -101,6 +110,9 @@ node() {
             cmd << "--dry-run"
         } else {
             cmd << "--push"
+            if (params.SYNC) {
+                cmd << "--sync"
+            }
         }
 
         echo "Will run: ${cmd.join(' ')}"


### PR DESCRIPTION
## Summary
- Exposes doozer's new `--sync` flag (openshift-eng/art-tools#3218) as a `SYNC` boolean job parameter on the `release-payload` Jenkins job.
- When `SYNC=true` on a non-dry-run build, doozer mirrors the built release payload manifest list and every per-arch image to `quay.io/openshift-release-dev/ocp-release`, each pinned by its own `sha256-<digest>` tag, to prevent quay garbage collection.
- `--sync` requires `--push`, so it's only appended in the non-dry-run branch and never combined with `--dry-run`.
- Surfaces the flag in the "Validate parameters" echo output and appends `[SYNC]` to the build display name when enabled.

## Test plan
- [ ] Run the `release-payload` job with `SYNC=false, DRY_RUN=false` and confirm the doozer command in the console log does not include `--sync`.
- [ ] Run the `release-payload` job with `SYNC=true, DRY_RUN=false` and confirm the doozer command includes `--push --sync`, and the payload is mirrored to `quay.io/openshift-release-dev/ocp-release`.
- [ ] Run the `release-payload` job with `DRY_RUN=true` and confirm `--sync` is never present regardless of the `SYNC` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)