### PR TITLE
Update payloadRelease suffix from .p0 to .p2

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -50,7 +50,7 @@ node() {
 
     commonlib.checkMock()
 
-    def payloadRelease = new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone('UTC')) + ".p0"
+    def payloadRelease = new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone('UTC')) + ".p2"
 
     currentBuild.displayName += " ${params.VERSION} - ${params.ASSEMBLY}"
     if (params.DRY_RUN) {


### PR DESCRIPTION
## Summary
- Update `payloadRelease` suffix from `.p0` to `.p2` in the release-payload Jenkinsfile

## Test plan
- Trigger the `release-payload` job and verify the payload version string ends with `.p2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)