### PR TITLE
Add NVR parameter to release-payload Jenkins job

### DIFF
--- a/jobs/build/release-payload/Jenkinsfile
+++ b/jobs/build/release-payload/Jenkinsfile
@@ -37,6 +37,12 @@ node() {
                     defaultValue: 'stream',
                     trim: true,
                 ),
+                string(
+                    name: 'NVR',
+                    description: 'If set, skip rebase and build — only sync this already-built payload NVR to quay.io. Requires a non-dry-run run.',
+                    defaultValue: '',
+                    trim: true,
+                ),
                 commonlib.dryrunParam('Do not push to git or trigger a Konflux build. Manifests are generated locally only.'),
                 booleanParam(
                     name: 'SYNC',
@@ -67,6 +73,7 @@ node() {
         echo "Will build release payload:"
         echo "  group:           openshift-${params.VERSION}"
         echo "  assembly:        ${params.ASSEMBLY}"
+        echo "  NVR:             ${params.NVR ?: '(build new)'}"
         echo "  payload release: ${payloadRelease}"
         echo "  dry run:         ${params.DRY_RUN}"
         echo "  sync:            ${params.SYNC}"
@@ -90,9 +97,13 @@ node() {
 
         cmd += [
             "beta:release-payload:rebase-and-build",
-            "--release", payloadRelease,
             "--registry-config", '${QUAY_AUTH_FILE}',
         ]
+        if (params.NVR?.trim()) {
+            cmd += ["--nvr", params.NVR.trim()]
+        } else {
+            cmd += ["--release", payloadRelease]
+        }
 
         if (params.DRY_RUN) {
             cmd << "--dry-run"


### PR DESCRIPTION
## Summary

- Adds a new optional `NVR` Jenkins parameter to the `release-payload` job
- When `NVR` is set, passes `--nvr <value>` to `doozer beta:release-payload:rebase-and-build` to skip rebase/build and only sync an already-built payload by its NVR
- When `NVR` is empty (default), behaviour is unchanged — `--release <timestamp>.p2` is passed as before
- Logs the NVR value in the "Validate parameters" stage output

Corresponds to the new `--nvr` flag added in https://github.com/openshift-eng/art-tools/pull/3218.

## Test plan

- [ ] Trigger the job with `NVR` empty — verify `--release <timestamp>.p2` appears in the echoed command
- [ ] Trigger the job with `NVR` set to a valid NVR string — verify `--nvr <value>` appears in the echoed command and `--release` is absent
- [ ] Dry-run with `NVR` set — verify `--dry-run` is still appended correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)