### PR TITLE
Disable PING_CHAI_BOT in images-health scheduled job

### DIFF
--- a/scheduled-jobs/scanning/images-health/Jenkinsfile
+++ b/scheduled-jobs/scanning/images-health/Jenkinsfile
@@ -21,7 +21,7 @@ node() {
                 parameters: [
                     booleanParam(name: 'SEND_TO_RELEASE_CHANNEL', value: true),
                     string(name: 'PUBLIC_CHANNEL', value: '#forum-ocp-art'),
-                    booleanParam(name: 'PING_CHAI_BOT', value: true),
+                    booleanParam(name: 'PING_CHAI_BOT', value: false),
                 ],
                 propagate: false,
             )


### PR DESCRIPTION
## Summary
- Sets `PING_CHAI_BOT` parameter to `false` in `scheduled-jobs/scanning/images-health/Jenkinsfile`

## Test plan
- Verify the images-health scheduled job runs without pinging the Chai bot