### PR TITLE
feat(olm-bundle-konflux): add FORCE_RELEASE parameter to Jenkins job

### DIFF
--- a/jobs/build/olm_bundle_konflux/Jenkinsfile
+++ b/jobs/build/olm_bundle_konflux/Jenkinsfile
@@ -84,6 +84,11 @@ node() {
                     description: 'Rebuild bundle containers, even if they already exist for given operator NVRs',
                     defaultValue: false,
                 ),
+                booleanParam(
+                    name: 'FORCE_RELEASE',
+                    description: 'Stage-release related images even if bundle containers were not rebuilt',
+                    defaultValue: false,
+                ),
                 string(
                     name: 'PLR_TEMPLATE_COMMIT',
                     description: '(Optional) Override the Pipeline Run template commit from openshift-priv/art-konflux-template; Format is ghuser@commitish e.g. jupierce@covscan-to-podman-2',
@@ -166,6 +171,8 @@ node() {
                     cmd << "--exclude=${exclude.join(',')}"
                 if (params.FORCE_BUILD)
                     cmd << "--force"
+                if (params.FORCE_RELEASE)
+                    cmd << "--force-release"
                 if (params.PLR_TEMPLATE_COMMIT) {
                     cmd << "--plr-template=${params.PLR_TEMPLATE_COMMIT}"
                 }


### PR DESCRIPTION
## Summary

- Adds a `FORCE_RELEASE` boolean parameter (default: false) to the `olm_bundle_konflux` Jenkins job
- When enabled, passes `--force-release` to `artcd olm-bundle-konflux`, which stage-releases related images even if no new bundle containers were rebuilt
- Mirrors the new `--force-release` flag added in [art-tools#3311](https://github.com/openshift-eng/art-tools/pull/3311)

## Test plan

- [ ] Run the job with `FORCE_RELEASE=false` (default) — verify `--force-release` is NOT in the artcd command (check job logs)
- [ ] Run the job with `FORCE_RELEASE=true` — verify `--force-release` IS passed to artcd and stage-release runs even with no new bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)