### PR TITLE
feat: schedule open-reconciliation-prs-layered-products and default to dry-run

### DIFF
--- a/jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
+++ b/jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
@@ -55,7 +55,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                         booleanParam(
                             name: 'DRY_RUN',
                             description: 'Run in dry-run mode (passes --moist-run to doozer PR operations)',
-                            defaultValue: false,
+                            defaultValue: true,
                         ),
                         commonlib.mockParam(),
                     ]

--- a/scheduled-jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
+++ b/scheduled-jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
@@ -1,0 +1,59 @@
+node {
+    checkout scm
+    buildlib = load("pipeline-scripts/buildlib.groovy")
+    commonlib = buildlib.commonlib
+    slacklib = commonlib.slacklib
+
+    properties( [
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '100', daysToKeepStr: '', numToKeepStr: '100')),
+        disableConcurrentBuilds(),
+        disableResume(),
+        [
+            $class: "ParametersDefinitionProperty",
+            parameterDefinitions: [
+                commonlib.artToolsParam(),
+                commonlib.mockParam(),
+            ]
+        ]
+    ] )
+
+    commonlib.checkMock()
+    buildlib.init_artcd_working_dir()
+
+    stage("schedule-open-reconciliation-prs-layered") {
+        cmd = [
+            "artcd",
+            "-v",
+            "--working-dir=${WORKSPACE}/artcd_working",
+            "--config=./config/artcd.toml",
+            "schedule-open-reconciliation-prs-layered"
+        ]
+        for ( group in commonlib.nonOCPGroups ) {
+            cmd << "--group=${group}"
+        }
+
+        withCredentials([
+                    string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                    string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
+                    string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD')]) {
+            wrap([$class: 'BuildUser']) {
+                builderEmail = env.BUILD_USER_EMAIL
+            }
+
+            withEnv(["BUILD_USER_EMAIL=${builderEmail?: ''}", "BUILD_URL=${BUILD_URL}", "JOB_NAME=${JOB_NAME}"]) {
+                try {
+                    echo "Will run ${cmd.join(' ')}"
+                    sh(script: cmd.join(' '), returnStdout: true)
+                } catch (err) {
+                    slacklib.to("#art-release").failure("Error running schedule-open-reconciliation-prs-layered", err)
+                    throw err
+                } finally {
+                    commonlib.safeArchiveArtifacts([
+                        "artcd_working/**/*.log",
+                    ])
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This PR introduces a daily scheduled job configuration for layered products open-reconciliation-prs and updates the existing manual job to default to dry-run (DRY_RUN=true).

### Changes:
- Created `scheduled-jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile` to schedule the reconciliation PR generator daily.
- Modified `jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile` to default `DRY_RUN` to `true`.