### PR TITLE
ART-23148: remove SKIP_PR param from golang-builder Jenkinsfile

### DIFF
--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -74,11 +74,6 @@ node {
                         description: 'Stream-type assembly to use for golang-builder operations. Defaults to stream.',
                     ),
                     booleanParam(
-                        name: 'SKIP_PR',
-                        description: 'Skip PR generation for ocp-build-data updates.',
-                        defaultValue: false,
-                    ),
-                    booleanParam(
                         name: 'EXTERNAL_GOLANG_RPMS',
                         description: 'Use golang RPMs from external repos (not tagged in rhaos build tags). Skips tagging and availability checks.',
                         defaultValue: false,
@@ -182,9 +177,6 @@ node {
                             cmd << "--build-system=${params.BUILD_SYSTEM}"
                         }
                         cmd << "--assembly=${params.ASSEMBLY}"
-                        if (params.SKIP_PR) {
-                            cmd << "--skip-pr"
-                        }
                         if (params.EXTERNAL_GOLANG_RPMS) {
                             cmd << "--external-golang-rpms"
                         }


### PR DESCRIPTION
## Summary

Removes the `SKIP_PR` parameter from the `golang-builder` Jenkins job. The
`--skip-pr` flag has been dropped from `artcd update-golang` in
openshift-eng/art-tools#3331 because the pipeline now uses floating tags in
`ocp-build-data/streams.yml` and no longer creates PRs on golang builder rebuilds.

## Changes

**`jobs/build/golang-builder/Jenkinsfile`**

- Remove `booleanParam(name: 'SKIP_PR', ...)` from the parameters block
- Remove `if (params.SKIP_PR) { cmd << "--skip-pr" }` from the command builder

Running a job with `SKIP_PR=true` after the art-tools change would crash with
`Error: No such option: --skip-pr`, so this needs to land together with or after
that PR.

## Related

- [ART-23148](https://redhat.atlassian.net/browse/ART-23148): Migrate ocp-build-data golang streams to floating tags
- art-tools companion: openshift-eng/art-tools#3331