### PR TITLE
ART-14447: add direct signing credentials to Jenkins jobs

### DIFF
--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -174,6 +174,9 @@ node {
             cmd << "--signing-env=${signing_env}"
             echo "Will run ${cmd.join(' ')}"
             def siging_cert_id = signing_env == "prod" ? "0xffe138e-openshift-art-bot" : "0xffe138d-nonprod-openshift-art-bot"
+            def direct_signing_keytab_id = "ocp-art-signing-${signing_env}.keytab"
+            def direct_signing_principal_id = "ocp-art-signing-${signing_env}.user"
+            def direct_signing_env_prefix = "DIRECT_SIGNING_${signing_env.toUpperCase()}"
             def sigstore_creds_file = signing_env == "prod" ? "kms_prod_release_signing_creds_file" : "kms_stage_release_signing_creds_file"
             def sigstore_key_id = signing_env == "prod" ? "kms_prod_release_signing_key_id" : "kms_stage_release_signing_key_id"
             buildlib.withAppCiAsArtPublish() {
@@ -187,6 +190,8 @@ node {
                                  string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                                  file(credentialsId: "${siging_cert_id}.crt", variable: 'SIGNING_CERT'),
                                  file(credentialsId: "${siging_cert_id}.key", variable: 'SIGNING_KEY'),
+                                 file(credentialsId: direct_signing_keytab_id, variable: "${direct_signing_env_prefix}_KEYTAB"),
+                                 string(credentialsId: direct_signing_principal_id, variable: "${direct_signing_env_prefix}_PRINCIPAL"),
                                  file(credentialsId: sigstore_creds_file, variable: 'KMS_CRED_FILE'),
                                  string(credentialsId: sigstore_key_id, variable: 'KMS_KEY_ID'),
                                  string(credentialsId: 'signing_rekor_url', variable: 'REKOR_URL'),

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -144,12 +144,17 @@ node {
 	        if (!needsHappening) { return }
                 def signing_env = params.DRY_RUN ? "stage" : "prod"
                 def signing_cert_id = signing_env == "prod" ? "0xffe138e-openshift-art-bot" : "0xffe138d-nonprod-openshift-art-bot"
+                def direct_signing_keytab_id = "ocp-art-signing-${signing_env}.keytab"
+                def direct_signing_principal_id = "ocp-art-signing-${signing_env}.user"
+                def direct_signing_env_prefix = "DIRECT_SIGNING_${signing_env.toUpperCase()}"
 
                 withCredentials([
                     file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                     string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
                     file(credentialsId: "${signing_cert_id}.crt", variable: 'SIGNING_CERT'),
                     file(credentialsId: "${signing_cert_id}.key", variable: 'SIGNING_KEY'),
+                    file(credentialsId: direct_signing_keytab_id, variable: "${direct_signing_env_prefix}_KEYTAB"),
+                    string(credentialsId: direct_signing_principal_id, variable: "${direct_signing_env_prefix}_PRINCIPAL"),
                 ]) {
                     buildlib.init_artcd_working_dir()
                     def dryrun = params.DRY_RUN ? "--dry-run" : ""


### PR DESCRIPTION
Keep UMB as the active signing transport while binding the environment-specific direct-signing keytabs and principals for the future cutover.


related to: https://github.com/openshift-eng/art-tools/pull/2809