### PR TITLE
fix(rhcos_sync): sign RHEL-10 stream container images (ART-23308)

### DIFF
--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -119,7 +119,7 @@ node {
         # Extract any additional per-stream boot image data (e.g. rhel-10 in OCP 5.x).
         # .data.streams is a map of stream-name -> stream-JSON; each may contain container
         # images that also need to be cosigned.
-        yq -r '(.data.streams // {}) | keys[]' \$tmp/coreos-bootimages.yaml 2>/dev/null | while read stream_name; do
+        yq -r '(.data.streams // {}) | keys[]' \$tmp/coreos-bootimages.yaml | while read stream_name; do
             stream_file="${env.WORKSPACE}/rhcos-${arch}-\${stream_name}.json"
             yq -r ".data.streams[\\"\\$stream_name\\"]" \$tmp/coreos-bootimages.yaml > "\$stream_file"
             echo "Extracted additional RHCOS stream: \$stream_name -> \$stream_file"
@@ -211,24 +211,29 @@ node {
                 // Sign container images from any additional streams (e.g. rhel-10 in OCP 5.x).
                 // The extraction step above writes rhcos-<arch>-<stream>.json for each entry
                 // found in .data.streams of the bootimages ConfigMap.
-                def extra_streams_cmd = """
-                    for stream_file in ${env.WORKSPACE}/rhcos-${arch}-*.json; do
-                        [ -f "\$stream_file" ] || continue
-                        echo "Signing additional RHCOS stream: \$stream_file"
-                        artcd -vv ${dryrun} \\
-                            --config=${env.WORKSPACE}/config/artcd.toml \\
-                            --working-dir=${env.WORKSPACE}/artcd_working \\
-                            sign-rhcos-containers \\
-                            --rhcos-file "\$stream_file" \\
-                            --arch ${arch} \\
-                            --signing-env ${signing_env}
-                    done
-                """
-                try {
-                    commonlib.shell(script: extra_streams_cmd)
-                } catch (err) {
-                    echo "WARNING: Failed to sign additional RHCOS stream container images: ${err}"
-                    currentBuild.description += "\n[WARNING] Additional RHCOS stream signing failed"
+                // Attempt every stream file and collect failures; throw after the loop so
+                // the job fails if any stream was not signed (avoids silent unsigned images).
+                def extraStreamFailures = []
+                def extraStreamFiles = findFiles(glob: "rhcos-${arch}-*.json")
+                for (streamFile in extraStreamFiles) {
+                    try {
+                        commonlib.shell(script: """
+                            echo "Signing additional RHCOS stream: ${streamFile}"
+                            artcd -vv ${dryrun} \\
+                                --config=${env.WORKSPACE}/config/artcd.toml \\
+                                --working-dir=${env.WORKSPACE}/artcd_working \\
+                                sign-rhcos-containers \\
+                                --rhcos-file ${streamFile} \\
+                                --arch ${arch} \\
+                                --signing-env ${signing_env}
+                        """)
+                    } catch (err) {
+                        echo "ERROR: Failed to sign stream ${streamFile}: ${err}"
+                        extraStreamFailures << streamFile.name
+                    }
+                }
+                if (extraStreamFailures) {
+                    error("Signing failed for extra RHCOS streams: ${extraStreamFailures.join(', ')}")
                 }
             }
         }

--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -116,6 +116,14 @@ node {
         oc image extract --path /manifests/:\$tmp \$(oc adm release info --image-for installer ${pullspec})
         cat \$tmp/coreos-bootimages.yaml | yq -r .data.stream > ${rhcos_file}
         cat \$tmp/coreos-bootimages.yaml | yq -r .data.stream | jq -r .architectures.${arch}.artifacts.qemu.release
+        # Extract any additional per-stream boot image data (e.g. rhel-10 in OCP 5.x).
+        # .data.streams is a map of stream-name -> stream-JSON; each may contain container
+        # images that also need to be cosigned.
+        yq -r '(.data.streams // {}) | keys[]' \$tmp/coreos-bootimages.yaml 2>/dev/null | while read stream_name; do
+            stream_file="${env.WORKSPACE}/rhcos-${arch}-\${stream_name}.json"
+            yq -r ".data.streams[\\"\\$stream_name\\"]" \$tmp/coreos-bootimages.yaml > "\$stream_file"
+            echo "Extracted additional RHCOS stream: \$stream_name -> \$stream_file"
+        done
         rm -rf \$tmp
     """
     rhcosBuild =  commonlib.shell(
@@ -199,6 +207,28 @@ node {
                 } catch (err) {
                     echo "WARNING: Failed to sign RHCOS container images: ${err}"
                     currentBuild.description += "\n[WARNING] RHCOS container signing failed"
+                }
+                // Sign container images from any additional streams (e.g. rhel-10 in OCP 5.x).
+                // The extraction step above writes rhcos-<arch>-<stream>.json for each entry
+                // found in .data.streams of the bootimages ConfigMap.
+                def extra_streams_cmd = """
+                    for stream_file in ${env.WORKSPACE}/rhcos-${arch}-*.json; do
+                        [ -f "\$stream_file" ] || continue
+                        echo "Signing additional RHCOS stream: \$stream_file"
+                        artcd -vv ${dryrun} \\
+                            --config=${env.WORKSPACE}/config/artcd.toml \\
+                            --working-dir=${env.WORKSPACE}/artcd_working \\
+                            sign-rhcos-containers \\
+                            --rhcos-file "\$stream_file" \\
+                            --arch ${arch} \\
+                            --signing-env ${signing_env}
+                    done
+                """
+                try {
+                    commonlib.shell(script: extra_streams_cmd)
+                } catch (err) {
+                    echo "WARNING: Failed to sign additional RHCOS stream container images: ${err}"
+                    currentBuild.description += "\n[WARNING] Additional RHCOS stream signing failed"
                 }
             }
         }


### PR DESCRIPTION
## Summary

OCP 5.x `coreos-bootimages.yaml` ships a second key `.data.streams` (a map of stream-name → stream-JSON) alongside the existing `.data.stream`. The `rhel-10` entry under `.data.streams` contains the RHEL 10 RHCOS kubevirt container disk images per arch.

Previously only `.data.stream` was extracted and passed to `sign-rhcos-containers`, leaving every RHEL-10 kubevirt image silently unsigned. This caused `SignatureValidationFailed` when HCP KubeVirt on IBM Z tried to pull the RHEL-10 boot image.

## Changes

1. **Extraction step**: after writing `rhcos-${arch}.json` from `.data.stream`, iterate `.data.streams.*` and write `rhcos-${arch}-${stream_name}.json` for each (no-op on releases without extra streams).
2. **Sign stage**: after the existing `sign-rhcos-containers` call, loop over `rhcos-${arch}-*.json` and sign each extra stream file.

## Testing

Retrigger `rhcos_sync` with `SIGN_ONLY=true` against `5.0.0-rc.1-s390x` and verify:
```bash
skopeo inspect --raw docker://quay.io/openshift-release-dev/ocp-v4.0-art-dev:sha256-79badc5fad21d22814d077560c10a90abd7d1896d415548281afbe3b7ea75861.sig
```
Should return a manifest with signature layers (not `manifest unknown`).

## Related
- Jira: [ART-23308](https://redhat.atlassian.net/browse/ART-23308)
- Bug: [OCPBUGS-86850](https://redhat.atlassian.net/browse/OCPBUGS-86850)