### PR TITLE
fix(rhcos_sync): fix Groovy GString interpolation in stream extraction (ART-23308)

### DIFF
--- a/jobs/build/rhcos_sync/Jenkinsfile
+++ b/jobs/build/rhcos_sync/Jenkinsfile
@@ -119,11 +119,20 @@ node {
         # Extract any additional per-stream boot image data (e.g. rhel-10 in OCP 5.x).
         # .data.streams is a map of stream-name -> stream-JSON; each may contain container
         # images that also need to be cosigned.
-        yq -r '(.data.streams // {}) | keys[]' \$tmp/coreos-bootimages.yaml | while read stream_name; do
-            stream_file="${env.WORKSPACE}/rhcos-${arch}-\${stream_name}.json"
-            yq -r ".data.streams[\\"\\$stream_name\\"]" \$tmp/coreos-bootimages.yaml > "\$stream_file"
-            echo "Extracted additional RHCOS stream: \$stream_name -> \$stream_file"
-        done
+        # Use Python to avoid Groovy GString interpolation conflicts with bash variables.
+        python3 -c "
+import yaml, json, sys
+data = yaml.safe_load(open('\$tmp/coreos-bootimages.yaml'))
+streams = data.get('data', {}).get('streams', {})
+if isinstance(streams, str):
+    streams = json.loads(streams)
+for name, content in streams.items():
+    if isinstance(content, str):
+        content = json.loads(content)
+    fname = '${env.WORKSPACE}/rhcos-${arch}-' + name + '.json'
+    json.dump(content, open(fname, 'w'))
+    print('Extracted additional RHCOS stream:', name, '->', fname)
+"
         rm -rf \$tmp
     """
     rhcosBuild =  commonlib.shell(


### PR DESCRIPTION
## Summary

Follow-up to #4816.

The bash `while read stream_name` loop inside a Groovy GString caused a runtime `MissingPropertyException` (build #3464): `\\\` in a Groovy GString is parsed as an escaped backslash followed by Groovy property lookup for `stream_name`, not as a bash variable.

Fix: replace the bash loop with an inline Python block. Only stable Groovy variables (`${env.WORKSPACE}`, `${arch}`) are interpolated; the stream name is handled entirely in Python.

## Jira
[ART-23308](https://redhat.atlassian.net/browse/ART-23308)