### PR TITLE
ART-18752: Expose shipment MR replacement in Jenkins

### DIFF
--- a/jobs/build/layered-products-prepare-release/Jenkinsfile
+++ b/jobs/build/layered-products-prepare-release/Jenkinsfile
@@ -63,6 +63,11 @@ node {
                         defaultValue: "",
                         trim: true,
                     ),
+                    booleanParam(
+                        name: 'FORCE',
+                        description: 'Create a replacement shipment MR and update releases.yml without closing the previous MR.',
+                        defaultValue: false,
+                    ),
                 ]
             ],
         ]
@@ -95,6 +100,10 @@ node {
                     "--assembly", "${params.ASSEMBLY}",
                     "--create-mr"
                 ]
+
+                if (params.FORCE) {
+                    cmd << "--force"
+                }
 
                 def buildDataUrl = params.BUILD_DATA_REPO_URL?.trim()
                 if (buildDataUrl) {

--- a/jobs/build/layered-products-prepare-release/Jenkinsfile
+++ b/jobs/build/layered-products-prepare-release/Jenkinsfile
@@ -65,7 +65,7 @@ node {
                     ),
                     booleanParam(
                         name: 'FORCE',
-                        description: 'Create a replacement shipment MR and update releases.yml without closing the previous MR.',
+                        description: 'Create a replacement shipment MR and update releases.yml. An open previous MR is made draft; replacement is refused if it was merged or production was attempted.',
                         defaultValue: false,
                     ),
                 ]

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -68,6 +68,11 @@ node {
                         description: 'Enable OCP optional-operator mode. Creates extras/fbc shipments with all FBC related images included. Use with GROUP=openshift-4.x.',
                         defaultValue: false,
                     ),
+                    booleanParam(
+                        name: 'FORCE',
+                        description: 'Create a replacement shipment MR and update releases.yml without closing the previous MR. Layered-product mode only.',
+                        defaultValue: false,
+                    ),
                     string(
                         name: 'EXCLUDE_NVR_COMPONENTS',
                         description: '(Optional) Comma-separated NVR component names to explicitly exclude from shipment. Not needed in the default workflow.',
@@ -138,6 +143,10 @@ node {
                     "${params.ASSEMBLY}",
                     "--create-mr"
                 ]
+
+                if (params.FORCE) {
+                    cmd << "--force"
+                }
 
                 def releaseJira = params.RELEASE_JIRA?.trim()
                 if (releaseJira) {

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -70,7 +70,7 @@ node {
                     ),
                     booleanParam(
                         name: 'FORCE',
-                        description: 'Create a replacement shipment MR and update releases.yml without closing the previous MR. Layered-product mode only.',
+                        description: 'Create a replacement shipment MR and update releases.yml. An open previous MR is made draft; replacement is refused if it was merged or production was attempted. Layered-product mode only.',
                         defaultValue: false,
                     ),
                     string(


### PR DESCRIPTION
## What changed

Adds a `FORCE` checkbox to both layered-product release jobs and a `TEST_MODE` checkbox to `release-from-fbc`.

- A normal rerun safely reuses the open MR recorded in `releases.yml` only after stage is terminal and before prod is attempted.
- `FORCE` creates a replacement MR and updates the pointer. An open previous stage-only MR is closed before replacement creation; a closed stage-only MR may also be replaced. Replacement is refused after any prod attempt or after the previous MR was merged.
- After the replacement pointer is stored, the previous MR receives a do-not-release comment linking the authoritative replacement and initiating job.
- `TEST_MODE` gives `release-from-fbc` an obvious test title and warning, keeps the MR draft, and does not automatically start Shipment CI. It defaults to disabled and does not change normal runs.

Direct releases can create this minimal entry:

```yaml
releases:
  1.5.3:
    assembly:
      type: stream
      group:
        shipment:
          mr: https://gitlab.example.com/group/shipment-data/-/merge_requests/123
```

Depends on [art-tools #3372](https://github.com/openshift-eng/art-tools/pull/3372).

Jira: [ART-18752](https://redhat.atlassian.net/browse/ART-18752)
