### PR TITLE
ART-23426: Rename node image post-build skip parameter

### DIFF
--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -127,8 +127,8 @@ node {
                         defaultValue: false,
                     ),
                     booleanParam(
-                        name: 'SKIP_RHCOS_INTEGRATION_TESTS',
-                        description: 'Skip RHCOS integration tests',
+                        name: 'SKIP_NODE_IMAGE_POST_BUILD_OPS',
+                        description: 'Skip node image post-build operations',
                         defaultValue: false,
                     ),
                     choice(
@@ -209,7 +209,7 @@ node {
             if (params.SKIP_EC_VERIFY) {
                 cmd << "--skip-ec-verify"
             }
-            if (params.SKIP_RHCOS_INTEGRATION_TESTS) {
+            if (params.SKIP_NODE_IMAGE_POST_BUILD_OPS) {
                 cmd << "--skip-rhcos-integration-tests"
             }
             if (params.NETWORK_MODE && params.NETWORK_MODE != "") {


### PR DESCRIPTION
## Summary

- Rename `SKIP_RHCOS_INTEGRATION_TESTS` to `SKIP_NODE_IMAGE_POST_BUILD_OPS`.
- Update the parameter description and pass `--skip-node-image-post-build-ops` to artcd.

## Test plan

- `git diff --check`
- Global `rh-pre-commit`
- Global `rh-pre-commit.commit-msg`