### PR TITLE
ART-23426: Provide Jenkins credentials to RHCOS post-build

### DIFF
--- a/jobs/build/rhcos-node-image-post-build/Jenkinsfile
+++ b/jobs/build/rhcos-node-image-post-build/Jenkinsfile
@@ -78,6 +78,8 @@ node {
             ]
 
             withCredentials([
+                string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
+                string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                 file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                 file(credentialsId: 'art-rhcos-images-sa', variable: 'RHCOS_QUAY_AUTH_FILE'),
                 file(credentialsId: 'rhcos--prod-pipeline_jenkins_api-prod-stable-spoke1-dc-iad2-itup-redhat-com', variable: 'RHCOS_JENKINS_KUBECONFIG'),


### PR DESCRIPTION
The RHCOS post-build pipeline now updates its ART Jenkins description with the triggered build-node-image URL and promoted pullspecs.

Build #6 succeeded, but the description update was skipped because the job did not bind JENKINS_SERVICE_ACCOUNT and JENKINS_SERVICE_ACCOUNT_TOKEN; art-tools logged:

```
KeyError: 'JENKINS_SERVICE_ACCOUNT'\n```\n\nBind the existing credentials so the description update can authenticate to ART Jenkins.