### PR TITLE
[ART-23211] reapply Jira credential update after revert

### DIFF
--- a/jobs/build/build-microshift/Jenkinsfile
+++ b/jobs/build/build-microshift/Jenkinsfile
@@ -131,7 +131,7 @@ node() {
                 }
                 withCredentials([
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                     string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),

--- a/jobs/build/check-bugs/Jenkinsfile
+++ b/jobs/build/check-bugs/Jenkinsfile
@@ -56,7 +56,7 @@ node {
         }
 
         buildlib.withAppCiAsArtPublish() {
-            withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+            withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
                 try {
                     sh(script: cmd.join(' '), returnStdout: true)
                 } catch (err) {

--- a/jobs/build/drop_advisories/Jenkinsfile
+++ b/jobs/build/drop_advisories/Jenkinsfile
@@ -60,7 +60,7 @@ node {
                 "--advisory", adv,
                 "--comment='${params.COMMENT}'"
             ]
-            withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+            withCredentials([string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
                 commonlib.shell(script: cmd.join(' '))
             }
         }

--- a/jobs/build/functional-tests/Jenkinsfile
+++ b/jobs/build/functional-tests/Jenkinsfile
@@ -45,7 +45,7 @@ node() {
                 string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                 string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                 file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
-                string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                 file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
             ]) {
                 dir("${env.WORKSPACE}/art-tools") {

--- a/jobs/build/golang-builder/Jenkinsfile
+++ b/jobs/build/golang-builder/Jenkinsfile
@@ -129,7 +129,7 @@ node {
                 string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                 string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                 file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                 file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
                 file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
             ]) {

--- a/jobs/build/layered-products-prepare-release/Jenkinsfile
+++ b/jobs/build/layered-products-prepare-release/Jenkinsfile
@@ -125,7 +125,7 @@ node {
                         string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                         string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                         string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                         file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                         file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),

--- a/jobs/build/layered-products/Jenkinsfile
+++ b/jobs/build/layered-products/Jenkinsfile
@@ -183,7 +183,7 @@ node {
                             file(credentialsId: 'konflux-bot-0-art-installer-agent-tenant-sa', variable: 'ASSISTED_INSTALLER_SA_KUBECONFIG'),
                             file(credentialsId: 'konflux-bot-0-art-coo-tenant-sa', variable: 'COO_KONFLUX_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                             string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                             file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                             string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),

--- a/jobs/build/ocp3/Jenkinsfile
+++ b/jobs/build/ocp3/Jenkinsfile
@@ -812,7 +812,7 @@ node {
 
                 echo "Will run ${cmd.join(' ')}"
                 try {
-                    withCredentials([string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                    withCredentials([string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
                         commonlib.shell(script: cmd.join(' '))
                     }
                 } catch (err) {

--- a/jobs/build/ocp4-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-konflux/Jenkinsfile
@@ -236,7 +236,7 @@ node {
                             string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                             file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                             string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                             string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                             file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),

--- a/jobs/build/ocp4-scan-konflux/Jenkinsfile
+++ b/jobs/build/ocp4-scan-konflux/Jenkinsfile
@@ -122,7 +122,7 @@ timeout(activity: true, time: 60, unit: 'MINUTES') {
                             file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                             file(credentialsId: 'creds_registry.redhat.io', variable: 'KONFLUX_OPERATOR_INDEX_AUTH_FILE'),
-                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         ]) {
                         // There is a vanishingly small race condition here, but it is not dangerous;
                         // it can only lead to undesired delays (i.e. waiting to scan while a build is ongoing).

--- a/jobs/build/ocp4/Jenkinsfile
+++ b/jobs/build/ocp4/Jenkinsfile
@@ -210,7 +210,7 @@ node {
                                 string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                                 string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                                 file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
-                                string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                                string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                                 file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                                 string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
                                 string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),

--- a/jobs/build/okd/Jenkinsfile
+++ b/jobs/build/okd/Jenkinsfile
@@ -152,7 +152,7 @@ node {
                                 string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                                 file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
                                 string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                                string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                                string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                                 string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                                 string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                                 file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),

--- a/jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
+++ b/jobs/build/open-reconciliation-prs-layered-products/Jenkinsfile
@@ -117,7 +117,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                     string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                     file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                 ]) {
                 wrap([$class: 'BuildUser']) {

--- a/jobs/build/open-reconciliation-prs/Jenkinsfile
+++ b/jobs/build/open-reconciliation-prs/Jenkinsfile
@@ -113,7 +113,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                     string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                     string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                 ]) {
                 wrap([$class: 'BuildUser']) {
                     builderEmail = env.BUILD_USER_EMAIL

--- a/jobs/build/operator-sdk_sync/Jenkinsfile
+++ b/jobs/build/operator-sdk_sync/Jenkinsfile
@@ -79,7 +79,7 @@ node {
                 withCredentials([
                 file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                 string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
-                string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
                     def out = sh(script: cmd.join(' '), returnStdout: true).trim()
                     echo out
                     if (out.contains('failed with')) {

--- a/jobs/build/prepare-release-konflux/Jenkinsfile
+++ b/jobs/build/prepare-release-konflux/Jenkinsfile
@@ -104,7 +104,7 @@ node() {
                         string(credentialsId: 'art-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
                         string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                         file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                         file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                         file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),

--- a/jobs/build/promote-assembly/Jenkinsfile
+++ b/jobs/build/promote-assembly/Jenkinsfile
@@ -181,7 +181,7 @@ node {
                                  file(credentialsId: 'aws-credentials-file', variable: 'AWS_SHARED_CREDENTIALS_FILE'),
                                  string(credentialsId: 's3-art-srv-enterprise-cloudflare-endpoint', variable: 'CLOUDFLARE_ENDPOINT'),
                                  string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                                 string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                                 string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                                  string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                                  string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                                  string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),

--- a/jobs/build/rebuild-golang-rpms/Jenkinsfile
+++ b/jobs/build/rebuild-golang-rpms/Jenkinsfile
@@ -116,7 +116,7 @@ node {
                     string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                     string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                     file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
-                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                     file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
                     string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                     string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),

--- a/jobs/build/release-from-fbc/Jenkinsfile
+++ b/jobs/build/release-from-fbc/Jenkinsfile
@@ -190,7 +190,7 @@ node {
                         file(credentialsId: 'konflux-bot-0-art-oap-tenant-sa', variable: 'OAP_KONFLUX_SA_KUBECONFIG'),
                         file(credentialsId: 'konflux-bot-0-art-quay-tenant-sa', variable: 'QUAY_KONFLUX_SA_KUBECONFIG'),
                         string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                         file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                         file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),

--- a/jobs/build/scan-for-kernel-bugs/Jenkinsfile
+++ b/jobs/build/scan-for-kernel-bugs/Jenkinsfile
@@ -85,7 +85,7 @@ node {
                         cmd << "--tracker=${tracker.trim()}"
                     }
                 }
-                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                withCredentials([string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'), string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
                     echo "Will run ${cmd.join(' ')}"
                     commonlib.shell(script: cmd.join(' '))
                 }

--- a/jobs/build/scan-osh/Jenkinsfile
+++ b/jobs/build/scan-osh/Jenkinsfile
@@ -103,7 +103,7 @@ node() {
                         string(credentialsId: 'jenkins-service-account', variable: 'JENKINS_SERVICE_ACCOUNT'),
                         string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
              ]) {
                 echo "Will run ${cmd.join(' ')}"
                 try {

--- a/jobs/build/seed-lockfile/Jenkinsfile
+++ b/jobs/build/seed-lockfile/Jenkinsfile
@@ -158,7 +158,7 @@ node {
                         string(credentialsId: 'jenkins-service-account-token', variable: 'JENKINS_SERVICE_ACCOUNT_TOKEN'),
                         file(credentialsId: 'konflux-bot-0-ocp-art-tenant-sa', variable: 'KONFLUX_SA_KUBECONFIG'),
                         string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         string(credentialsId: 'openshift-bot-token', variable: 'GITHUB_TOKEN'),
                         string(credentialsId: 'openshift-art-build-bot-app-id', variable: 'GITHUB_APP_ID'),
                         file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),

--- a/jobs/build/sync-ci-images/Jenkinsfile
+++ b/jobs/build/sync-ci-images/Jenkinsfile
@@ -148,7 +148,7 @@ timeout(activity: true, time: 120, unit: 'MINUTES') {
                             string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
                             file(credentialsId: 'quay-auth-file', variable: 'QUAY_AUTH_FILE'),
                             file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                            string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                            string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                             usernamePassword(credentialsId: 'art_to_ci_promotion_robot--qci', usernameVariable: 'QCI_USER', passwordVariable: 'QCI_PASSWORD'),
                         ]) {
                         wrap([$class: 'BuildUser']) {

--- a/jobs/build/tag-rpms/Jenkinsfile
+++ b/jobs/build/tag-rpms/Jenkinsfile
@@ -66,7 +66,7 @@ node {
                 }
                 withCredentials([
                         string(credentialsId: 'art-bot-slack-token', variable: 'SLACK_BOT_TOKEN'),
-                        string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                        string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                         string(credentialsId: 'redis-server-password', variable: 'REDIS_SERVER_PASSWORD'),
                     ]) {
                     echo "Will run ${cmd.join(' ')}"

--- a/jobs/scanning/images-health/Jenkinsfile
+++ b/jobs/scanning/images-health/Jenkinsfile
@@ -121,7 +121,7 @@ node() {
                      file(credentialsId: 'openshift-art-build-bot-private-key.pem', variable: 'GITHUB_APP_PRIVATE_KEY_PATH'),
                      usernamePassword(credentialsId: 'art-dash-db-login', passwordVariable: 'DOOZER_DB_PASSWORD', usernameVariable: 'DOOZER_DB_USER'),
                      file(credentialsId: 'konflux-gcp-app-creds-prod', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-                     string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN')]) {
+                     string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN')]) {
 
         wrap([$class: 'BuildUser']) {
             builderEmail = env.BUILD_USER_EMAIL

--- a/scheduled-jobs/build/update-shipyard/Jenkinsfile
+++ b/scheduled-jobs/build/update-shipyard/Jenkinsfile
@@ -67,7 +67,7 @@ node() {
             ]) {
                 withCredentials([
                     string(credentialsId: 'shipyard-bot-jenkins-gitlab', variable: 'GITLAB_TOKEN'),
-                    string(credentialsId: 'jboss-jira-token', variable: 'JIRA_TOKEN'),
+                    string(credentialsId: 'jira-bot-token', variable: 'JIRA_TOKEN'),
                 ]) {
                     dir('shipyard') {
                         deleteDir()


### PR DESCRIPTION
This reapplies the credential ID changes from #4809 after #4810 reverted them.

- Replace `jboss-jira-token` with `jira-bot-token` in the affected Jenkinsfiles.
- Preserve the later `quay-auth-file` addition in `open-reconciliation-prs-layered-products/Jenkinsfile`.
- The 26 Jenkinsfiles pass Groovy syntax-only parsing and repository commit hooks.